### PR TITLE
Fix/dashboard highlight

### DIFF
--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -19,7 +19,7 @@ import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {getCurrentChannelStats} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannel, getCurrentChannelStats} from 'mattermost-redux/selectors/entities/channels';
 
 import {browserHistory} from 'utils/browser_history';
 import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
@@ -50,6 +50,16 @@ import {equalServerVersions} from 'utils/server_version';
 
 const dispatch = store.dispatch;
 const getState = store.getState;
+
+export function getCurrentPage(match) {
+    console.log("using match:",  match);
+    if (match.params.path == 'pages') {
+        console.log("match returning", match.params.identifier)
+        return match.params.identifier;
+    } else {
+        return null;
+    }
+}
 
 export function emitChannelClickEvent(channel) {
     async function userVisitedFakeChannel(chan, success, fail) {

--- a/components/channel_layout/center_channel/center_channel.jsx
+++ b/components/channel_layout/center_channel/center_channel.jsx
@@ -67,10 +67,6 @@ export default class CenterChannel extends React.PureComponent {
                             )}
                         />
                         <Route
-                            path={'/:team/:path(channels|messages)/dashboard'}
-                            component={Dashboard}
-                        />
-                        <Route
                             path={'/:team/:path(channels|messages)/:identifier'}
                             component={ChannelIdentifierRouter}
                         />

--- a/components/dashboard/DashboardView.js
+++ b/components/dashboard/DashboardView.js
@@ -112,7 +112,6 @@ const MeetingList = ({
 };
 
 const DashboardView = (props) => {
-    console.log("user:", props.user);
     if (props.fetchMeetingsStatus === 'loading') {
         return (
             <div className='columns is-centered has-text-centered'>
@@ -177,15 +176,7 @@ const DashboardView = (props) => {
                         />
                       </div>
                     </div>
-                    <div
-                        className='section'
-                        style={{padding: '0px'}}
-                    >
-                        <TimelineChart
-                            processedTimeline={props.processedTimeline}
-                            participantId={props.user.id}
-                        />
-                    </div>
+
                 </div>
             )}
         </div>

--- a/components/needs_team/needs_team.jsx
+++ b/components/needs_team/needs_team.jsx
@@ -16,6 +16,7 @@ import {loadProfilesForSidebar} from 'actions/user_actions.jsx';
 import {makeAsyncComponent} from 'components/async_load';
 import loadBackstageController from 'bundle-loader?lazy!components/backstage';
 import ChannelController from 'components/channel_layout/channel_controller';
+import PageController from 'components/page_layout/page_controller';
 import WebRtcController from 'components/webrtc_layout/webrtc_controller';
 import { customTheme } from './theme.js'
 
@@ -233,32 +234,41 @@ export default class NeedsTeam extends React.Component {
         const teamType = this.state.team ? this.state.team.type : '';
         return (
             <Switch>
-                <Route
-                    path={'/:team/integrations'}
-                    component={BackstageController}
+              <Route
+                path={'/:team/integrations'}
+                component={BackstageController}
+                />
+              <Route
+                path={'/:team/emoji'}
+                component={BackstageController}
+                />
+              <Route
+                exact
+                path={'/:team/:path(pages)/:identifier'}
+                render={(renderProps) => (
+                    <PageController
+                      pathName={renderProps.location.pathname}
+                      teamType={teamType}/>
+                )}
+                />
+              <Route
+                exact
+                path={'/:team/:identifier/video/:videoId'}
+                render={(renderProps) => (
+                    <WebRtcController
+                      pathName={renderProps.location.pathname}
+                      teamType={teamType}/>
+                )}
                 />
                 <Route
-                    path={'/:team/emoji'}
-                    component={BackstageController}
+                render={(renderProps) => (
+                <ChannelController
+                  pathName={renderProps.location.pathname}
+                  teamType={teamType}
                   />
-                <Route
-                  exact
-                  path={'/:team/:identifier/video/:videoId'}
-                  render={(renderProps) => (
-                      <WebRtcController
-                        pathName={renderProps.location.pathname}
-                        teamType={teamType}/>
-                  )}
-                  />
-                <Route
-                    render={(renderProps) => (
-                        <ChannelController
-                            pathName={renderProps.location.pathname}
-                            teamType={teamType}
-                        />
-                    )}
+            )}
                 />
-            </Switch>
+                </Switch>
         );
     }
 }

--- a/components/page_layout/Page/index.jsx
+++ b/components/page_layout/Page/index.jsx
@@ -1,0 +1,13 @@
+import {connect} from 'react-redux';
+import {getIsRhsOpen, getIsRhsMenuOpen} from 'selectors/rhs';
+import {getLastViewedChannelNameByTeamName} from 'selectors/local_storage';
+
+import Page from './page';
+
+const mapStateToProps = (state, ownProps) => ({
+    lastChannelPath: `${ownProps.match.url}/channels/${getLastViewedChannelNameByTeamName(state, ownProps.match.params.team)}`,
+    rhsOpen: getIsRhsOpen(state),
+    rhsMenuOpen: getIsRhsMenuOpen(state)
+});
+
+export default connect(mapStateToProps)(Page);

--- a/components/page_layout/Page/page.jsx
+++ b/components/page_layout/Page/page.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Route, Switch, Redirect} from 'react-router-dom';
+import classNames from 'classnames';
+import Dashboard from 'components/dashboard';
+
+import PermalinkView from 'components/permalink_view';
+import Navbar from 'components/navbar';
+
+export default class Page extends React.PureComponent {
+    static propTypes = {
+        match: PropTypes.shape({
+            params: PropTypes.shape({
+                identifier: PropTypes.string.isRequired,
+                team: PropTypes.string.isRequired
+            }).isRequired,
+        }).isRequired,
+        location: PropTypes.object.isRequired,
+        // TODO: possible this should be last video path instead
+        // to redirect to the right videochat they were last at.
+    };
+
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return (
+            <div
+                key='inner-wrap'
+                className={classNames('inner-wrap', 'channel__wrap', {
+                    'move--right': this.props.lhsOpen,
+                    'move--left': this.props.rhsOpen,
+                    'move--left-small': this.props.rhsMenuOpen,
+                })}
+            >
+                <div className='row header'>
+                    <div id='navbar'>
+                        <Navbar/>
+                    </div>
+                </div>
+                <div className='row main'>
+                    <Switch>
+                        <Route
+                        path={'/:team/pages/:identifier(dashboard)'}
+                        component={Dashboard}
+                        />
+                    </Switch>
+                </div>
+            </div>
+        );
+    }
+} 

--- a/components/page_layout/page_controller.jsx
+++ b/components/page_layout/page_controller.jsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {Route} from 'react-router-dom';
+
+import Pluggable from 'plugins/pluggable';
+import AnnouncementBar from 'components/announcement_bar';
+import SystemNotice from 'components/system_notice';
+import EditPostModal from 'components/edit_post_modal';
+import GetPostLinkModal from 'components/get_post_link_modal';
+import GetTeamInviteLinkModal from 'components/get_team_invite_link_modal';
+import GetPublicLinkModal from 'components/get_public_link_modal';
+import InviteMemberModal from 'components/invite_member_modal';
+import LeavePrivateChannelModal from 'components/modals/leave_private_channel_modal.jsx';
+import RemovedFromChannelModal from 'components/removed_from_channel_modal.jsx';
+import ResetStatusModal from 'components/reset_status_modal';
+import ShortcutsModal from 'components/shortcuts_modal.jsx';
+import SidebarRight from 'components/sidebar_right';
+import SidebarRightMenu from 'components/sidebar_right_menu';
+import TeamSettingsModal from 'components/team_settings_modal.jsx';
+import ImportThemeModal from 'components/user_settings/import_theme_modal.jsx';
+import UserSettingsModal from 'components/user_settings/modal';
+import ModalController from 'components/modal_controller';
+import TeamSidebar from 'components/team_sidebar';
+import Sidebar from 'components/sidebar';
+import * as Utils from 'utils/utils';
+import CenterChannel from 'components/channel_layout/center_channel';
+
+import Page from 'components/page_layout/Page';
+
+
+export default class WebrtcController extends React.Component {
+    static propTypes = {
+        pathName: PropTypes.string.isRequired,
+        teamType: PropTypes.string.isRequired
+    };
+
+    render() {
+        return (
+            <div className='channel-view'>
+              <AnnouncementBar/>
+              <SystemNotice/>
+
+              <div className='container-fluid'>
+                <SidebarRight/>
+                <SidebarRightMenu teamType={this.props.teamType}/>
+                <Route component={TeamSidebar}/>
+                <Route component={Sidebar}/>
+                <Route component={Page}/>
+                <Pluggable pluggableName='Root'/>
+                <UserSettingsModal/>
+                <GetPostLinkModal/>
+                <GetPublicLinkModal/>
+                <GetTeamInviteLinkModal/>
+                <InviteMemberModal/>
+                <ImportThemeModal/>
+                <TeamSettingsModal/>
+                <EditPostModal/>
+                <RemovedFromChannelModal/>
+                <ResetStatusModal/>
+                <LeavePrivateChannelModal/>
+                <ShortcutsModal isMac={Utils.isMac()}/>
+                <ModalController/>
+              </div>
+            </div>
+        );
+    }
+}

--- a/components/sidebar/index.js
+++ b/components/sidebar/index.js
@@ -26,12 +26,14 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {GroupUnreadChannels} from 'utils/constants.jsx';
 import {close} from 'actions/views/lhs';
 import {getIsLhsOpen} from 'selectors/lhs';
+import {getCurrentPage} from 'actions/global_actions';
 
 import Sidebar from './sidebar.jsx';
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
     const config = getConfig(state);
     const currentChannel = getCurrentChannel(state);
+    const currentPage = getCurrentPage(ownProps.match);
     const currentTeammate = currentChannel && currentChannel.teammate_id && getCurrentChannel(state, currentChannel.teammate_id);
     let publicChannelIds;
     let privateChannelIds;
@@ -78,6 +80,7 @@ function mapStateToProps(state) {
         unreadChannelIds: getSortedUnreadChannelIds(state, keepChannelIdAsUnread),
         currentChannel,
         currentTeammate,
+        currentPage,
         currentTeam: getCurrentTeam(state),
         currentUser: getCurrentUser(state),
         unreads: getUnreads(state),

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -480,7 +480,7 @@ export default class Sidebar extends React.PureComponent {
                 key={channelId}
                 ref={channelId}
                 channelId={channelId}
-                active={channelId === this.props.currentChannel.id}
+                active={channelId === this.props.currentChannel.id && this.props.currentPage === null}
                 currentTeamName={this.props.currentTeam.name}
                 currentUserId={this.props.currentUser.id}
             />
@@ -532,12 +532,14 @@ export default class Sidebar extends React.PureComponent {
         );
 
         var dashboard = (
-            <li key='dashboard'>
+            <li key='dashboard' className={this.props.currentPage === 'dashboard' ? 'active' : ''}>
                 <button
                     id='dashboard'
                     className='nav-more cursor--pointer style--none btn--block'
                     onClick={
-                        () => { this.props.history.push(`/${this.props.currentTeam.name}/channels/dashboard`) }
+                        () => {
+                            browserHistory.push(`/${this.props.currentTeam.name}/pages/dashboard`)
+                        }
                     }
                 >
 


### PR DESCRIPTION
Dashboard menu item is now correctly highlighted when user is on that page.

#### Summary
- adds a new routing component for "pages", a top-level construct that isn't a channel or a DM group
- adds logic to sidebar to check if user is in a page or non-page 

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
