### PR TITLE
Changing videochat limit text to be 7 instead of 6

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -362,10 +362,10 @@ export default class ChannelHeader extends React.Component {
                   Riff chat is disabled until the page fully loads.
                 </span>
             );
-        } else if (this.props.channelStats.member_count > 6) {
+        } else if (this.props.channelStats.member_count > 7) {
             tooltipContent = (
                 <span >
-                  Riff video chat only supports groups up to 6 people. Create a new DM group to start a call.
+                  Riff video chat only supports groups up to 7 people. Create a new DM group to start a call.
                   <button
                     className='add-channel-btn cursor--pointer btn-primary btn'
                     style={{marginTop: '.5rem', marginBottom: '.5rem'}}


### PR DESCRIPTION
Simple fix to video chat link tooltip text to limit the number of people in a channel for a videochat to 7. 

#### Summary
[A brief description of what this pull request does.]

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
