### PR TITLE
Fix/webrtc chat leave

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -395,6 +395,7 @@ export default class ChannelHeader extends React.Component {
               >
               <Link target="_blank"
                     id="videochat"
+                    disabled={this.webRtcDisabled}
                     to={this.props.webRtcLink}
                     onClick={() => {this.props.actions.sendWebRtcMessage(this.props.channel.id,this.props.currentUser.id, this.props.webRtcLink, this.props.currentTeam.name); }}>
                 <PopoverStickOnHover

--- a/components/webrtc_view_bulma/LeaveRoomButton.jsx
+++ b/components/webrtc_view_bulma/LeaveRoomButton.jsx
@@ -12,9 +12,6 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
-    redirect: () => {
-        dispatch(push("/"));
-    }
 });
 
 const mapMergeProps = (stateProps, dispatchProps, ownProps) => ({
@@ -27,7 +24,6 @@ const mapMergeProps = (stateProps, dispatchProps, ownProps) => ({
         ownProps.leaveRoom();
         ownProps.webrtc.leaveRoom();
         ownProps.webrtc.stopSibilant();
-        dispatchProps.redirect();
     }
 });
 

--- a/components/webrtc_view_bulma/RenderVideos.jsx
+++ b/components/webrtc_view_bulma/RenderVideos.jsx
@@ -22,7 +22,7 @@ class RenderVideos extends React.Component {
             return (
                 <div style={{width: '100%', alignItems: 'center'}}className="columns is-centered is-vcentered">
                   <div className="column">
-                    {!this.props.inRoom && !this.props.riff.meetingId ?
+                    {!this.props.inRoom || !this.props.riff.meetingId ?
 
                         <React.Fragment>
                               {this.props.displayRoomName &&


### PR DESCRIPTION
This fix moves users to the videochat lobby instead of a strange in-between state when they hang up a webRTC call.

#### Summary
- Changes 'views.webrtc.inRoom' state when user leaves room correctly.

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
