### PR TITLE
Fix/meeting link generation

### DIFF
--- a/actions/webrtc_channel_actions.js
+++ b/actions/webrtc_channel_actions.js
@@ -2,15 +2,14 @@ import {getTimestamp} from 'utils/utils.jsx';
 import {emitUserPostedEvent, postListScrollChangeToBottom} from 'actions/global_actions';
 import {createPost} from 'actions/post_actions';
 import {app, socket} from 'utils/riff';
+import parse from 'url-parse';
 
 
 export const sendWebRtcMessage = (currentChannelId, userId, webRtcLink, teamName) => (dispatch) => {
     const time = getTimestamp();
-    console.log("teamName:", teamName)
 
-    const fullLink = window.location.href.split(teamName)[0] + webRtcLink;
     let post = {
-        message: "I started a Riff meeting! Join here: " + fullLink,
+        message: "I started a Riff meeting! Join here: " + webRtcLink,
         channel_id: currentChannelId,
         pending_post_id: `${userId}:${time}`,
         create_at: time,

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -1,6 +1,5 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-
 import PropTypes from 'prop-types';
 import React from 'react';
 import {OverlayTrigger, Popover, Tooltip} from 'react-bootstrap';
@@ -9,6 +8,8 @@ import {Permissions} from 'mattermost-redux/constants';
 import {memoizeResult} from 'mattermost-redux/utils/helpers';
 import {Link} from 'react-router-dom';
 import parse from 'url-parse';
+import {getTimestamp} from 'utils/utils.jsx';
+import { createWebRtcLink } from 'utils/webrtc/webrtc';
 
 import 'bootstrap';
 
@@ -287,6 +288,8 @@ export default class ChannelHeader extends React.Component {
         actions.openModal(inviteModalData);
     };
 
+
+
     renderMute = () => {
         const channelMuted = isChannelMuted(this.props.channelMember);
 
@@ -348,6 +351,18 @@ export default class ChannelHeader extends React.Component {
         } else {
             this.showMoreDirectChannelsModal();
         }
+    }
+
+    makePostToSend = (channelId) => {
+        const time = getTimestamp();
+
+        let webRtcLink = createWebRtcLink(this.props.currentTeam.name, channelId);
+        let post = {
+            message: "I started a Riff meeting! Join here: " + webRtcLink.href,
+            channel_id: channelId,
+            pending_post_id: `${this.props.userId}:${time}`,
+            create_at: time,
+        };
     }
 
     webRtcDisabled = () => {
@@ -474,6 +489,7 @@ export default class ChannelHeader extends React.Component {
                 <MoreDirectChannels
                   onModalDismissed={this.hideMoreDirectChannelsModal}
                   isExistingChannel={false}
+                  makePostToSend={this.makePostToSend}
                   />
             );
         }

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -397,7 +397,7 @@ export default class ChannelHeader extends React.Component {
                     id="videochat"
                     disabled={this.webRtcDisabled()}
                     to={this.props.webRtcLink.pathname}
-                    onClick={() => {this.props.actions.sendWebRtcMessage(this.props.channel.id,this.props.currentUser.id, this.props.webRtcLink.href, this.props.currentTeam.name); }}>
+                    onClick={() => { if (!this.webRtcDisabled()) { this.props.actions.sendWebRtcMessage(this.props.channel.id,this.props.currentUser.id, this.props.webRtcLink.href, this.props.currentTeam.name) } }}>
                 <PopoverStickOnHover
                   component={webrtcTooltip}
                   placement="bottom"

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -363,6 +363,7 @@ export default class ChannelHeader extends React.Component {
             pending_post_id: `${this.props.userId}:${time}`,
             create_at: time,
         };
+        return post;
     }
 
     webRtcDisabled = () => {

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -8,6 +8,7 @@ import {FormattedMessage} from 'react-intl';
 import {Permissions} from 'mattermost-redux/constants';
 import {memoizeResult} from 'mattermost-redux/utils/helpers';
 import {Link} from 'react-router-dom';
+import parse from 'url-parse';
 
 import 'bootstrap';
 
@@ -63,7 +64,7 @@ export default class ChannelHeader extends React.Component {
             openModal: PropTypes.func.isRequired,
             getCustomEmojisInText: PropTypes.func.isRequired,
             updateChannelNotifyProps: PropTypes.func.isRequired,
-            goToLastViewedChannel: PropTypes.func.isRequired,
+            //goToLastViewedChannel: PropTypes.func.isRequired,
             sendWebRtcMessage: PropTypes.func.isRequired,
         }).isRequired,
         channel: PropTypes.object.isRequired,
@@ -394,9 +395,9 @@ export default class ChannelHeader extends React.Component {
               >
               <Link target="_blank"
                     id="videochat"
-                    disabled={this.webRtcDisabled}
-                    to={this.props.webRtcLink}
-                    onClick={() => {this.props.actions.sendWebRtcMessage(this.props.channel.id,this.props.currentUser.id, this.props.webRtcLink, this.props.currentTeam.name); }}>
+                    disabled={this.webRtcDisabled()}
+                    to={this.props.webRtcLink.pathname}
+                    onClick={() => {this.props.actions.sendWebRtcMessage(this.props.channel.id,this.props.currentUser.id, this.props.webRtcLink.href, this.props.currentTeam.name); }}>
                 <PopoverStickOnHover
                   component={webrtcTooltip}
                   placement="bottom"

--- a/components/channel_header/index.js
+++ b/components/channel_header/index.js
@@ -69,7 +69,7 @@ function mapStateToProps(state, ownProps) {
         isReadOnly: isCurrentChannelReadOnly(state),
         lastViewedChannelName,
         penultimateViewedChannelName,
-        webRtcLink: getWebRtcLink(state, ownProps),
+        webRtcLink: getWebRtcLink(state, ownProps)
     };
 }
 

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -6,6 +6,8 @@ import React from 'react';
 import {Modal} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 import {Client4} from 'mattermost-redux/client';
+import {emitUserPostedEvent, postListScrollChangeToBottom} from 'actions/global_actions';
+import {createPost} from 'actions/post_actions';
 
 import {browserHistory} from 'utils/browser_history';
 import {openDirectChannelToUser, openGroupChannelToUsers} from 'actions/channel_actions.jsx';
@@ -181,7 +183,10 @@ export default class MoreDirectChannels extends React.Component {
             this.setState({saving: false});
             this.handleHide();
             if (this.props.makePostToSend) {
-                this.props.makePostToSend(channel.name);
+                let post = this.props.makePostToSend(channel.id);
+                emitUserPostedEvent(post);
+                createPost(post,[]);
+                postListScrollChangeToBottom();
             }
         };
 

--- a/components/more_direct_channels/more_direct_channels.jsx
+++ b/components/more_direct_channels/more_direct_channels.jsx
@@ -46,6 +46,8 @@ export default class MoreDirectChannels extends React.Component {
         onModalDismissed: PropTypes.func,
         onHide: PropTypes.func,
 
+        makePostToSend: PropTypes.func,
+
         actions: PropTypes.shape({
             getProfiles: PropTypes.func.isRequired,
             getProfilesInTeam: PropTypes.func.isRequired,
@@ -138,6 +140,7 @@ export default class MoreDirectChannels extends React.Component {
         this.setState({show: false});
     }
 
+
     setUsersLoadingState = (loadingState) => {
         this.setState({
             loadingUsers: loadingState,
@@ -177,6 +180,9 @@ export default class MoreDirectChannels extends React.Component {
             this.exitToChannel = '/' + this.props.currentTeamName + '/channels/' + channel.name;
             this.setState({saving: false});
             this.handleHide();
+            if (this.props.makePostToSend) {
+                this.props.makePostToSend(channel.name);
+            }
         };
 
         const error = () => {

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "superagent": "3.8.3",
     "twemoji": "11.0.1",
     "underscore": "^1.9.1",
+    "url-parse": "^1.4.4",
     "url-search-params-polyfill": "4.0.1",
     "webrtc-adapter": "^6.4.4",
     "whatwg-fetch": "2.0.4",

--- a/utils/webrtc/webrtc.js
+++ b/utils/webrtc/webrtc.js
@@ -2,11 +2,15 @@ import SimpleWebRtc from 'simplewebrtc';
 import * as WebRtcActions from '../../actions/webrtc_actions';
 import sibilant from 'sibilant-webaudio';
 import { app, socket } from '../riff';
-import {updateRiffMeetingId} from '../../actions/views/riff'
+import {updateRiffMeetingId} from '../../actions/views/riff';
+import parse from 'url-parse';
 
 
 export const createWebRtcLink = (teamName, channelName) => {
-    return '/' + teamName + '/' + channelName + '/video' + '/' + generateUID();
+    let link = parse(window.location.href, true);
+    link.set('pathname', teamName + '/' + channelName + '/' + 'video' + '/' + generateUID());
+    console.log("Created webrtc Link:", link.href);
+    return link;
 }
 
 function generateUID() {


### PR DESCRIPTION
Meeting links should now be generated appropriately, using a URL parser instead of naive string manipulation. Links are no longer sent in the too-large-channels when a user chooses to create a new DM group

#### Summary
[A brief description of what this pull request does.]

#### Ticket Link
[Please link the GitHub issue or Jira ticket this PR addresses.]

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
