### PR TITLE
Expanded color palette to accommodate 7 people

### DIFF
--- a/reducers/views/webrtc.js
+++ b/reducers/views/webrtc.js
@@ -2,7 +2,7 @@ import {joinWebRtcRoom} from '../../actions/webrtc_actions';
 import {WebRtcActionTypes, ActionTypes} from '../../utils/constants';
 
 const initialState = {
-    peerColors: ['#f56b6b', '#128EAD', '#7caf5f', '#f2a466'],
+    peerColors: ['#f56b6b', '#128EAD', '#7caf5f', '#f2a466', '#321325', '#3C493F', '#1B998B'],
     getMediaStatus: 'error',
     getMediaMessage: '',
 


### PR DESCRIPTION
#### Summary
Added three new colors to the color palette in the reducer.

PR in riff-rtc:
https://github.com/rifflearning/riff-rtc/pull/32

#### Ticket Link
https://trello.com/c/eAhpZ8tZ/201-expand-color-palette-to-accommodate-7-people

#### Checklist
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
