### PR TITLE
Lti Auth

### DIFF
--- a/components/signup/signup_lti/signup_lti.jsx
+++ b/components/signup/signup_lti/signup_lti.jsx
@@ -105,6 +105,9 @@ export default class SignupLTI extends React.Component {
             const {data, error} = await this.props.actions.createLTIUser({password: this.refs.password.value});
             if (data) {
                 this.deleteCookie(LTIConstants.LAUNCH_DATA_COOKIE);
+                if (data.redirect) {
+                    window.location.href = data.redirect;
+                }
             }
             if (error) {
                 this.setState({

--- a/components/signup/signup_lti/signup_lti.jsx
+++ b/components/signup/signup_lti/signup_lti.jsx
@@ -103,7 +103,6 @@ export default class SignupLTI extends React.Component {
             });
 
             const {data, error} = await this.props.actions.createLTIUser({password: this.refs.password.value});
-            console.log(data, error);
             if (data) {
                 this.deleteCookie(LTIConstants.LAUNCH_DATA_COOKIE);
             }

--- a/components/signup/signup_lti/signup_lti.jsx
+++ b/components/signup/signup_lti/signup_lti.jsx
@@ -103,6 +103,7 @@ export default class SignupLTI extends React.Component {
             });
 
             const {data, error} = await this.props.actions.createLTIUser({password: this.refs.password.value});
+            console.log(data, error);
             if (data) {
                 this.deleteCookie(LTIConstants.LAUNCH_DATA_COOKIE);
             }

--- a/components/signup/signup_lti/signup_lti.jsx
+++ b/components/signup/signup_lti/signup_lti.jsx
@@ -59,6 +59,10 @@ export default class SignupLTI extends React.Component {
         return parts ? parts.pop() : '';
     };
 
+    deleteCookie = (name) => {
+        document.cookie = name + '=;expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+    };
+
     extractFormData = () => {
         return this.getCookie(LTIConstants.LAUNCH_DATA_COOKIE);
     };
@@ -100,8 +104,7 @@ export default class SignupLTI extends React.Component {
 
             const {data, error} = await this.props.actions.createLTIUser({password: this.refs.password.value});
             if (data) {
-                // TODO: update this when login flow is complete
-                browserHistory.push('/');
+                this.deleteCookie(LTIConstants.LAUNCH_DATA_COOKIE);
             }
             if (error) {
                 this.setState({

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2532,7 +2532,7 @@
   "signup_LTI.fullname": "Full Name",
   "signup_LTI.position": "Position",
   "signup_LTI.username": "Username",
-  "signup_LTI.invalid_request": "There was an error with your login request. Please try again or contact your system administrator.",
+  "signup_LTI.invalid_request": "There was an error with your login request. Please try again or contact your system administrator. Error code LTI-27",
   "signup.office365": "Office 365",
   "signup.saml.icon": "SAML Icon",
   "signup.title": "Create an account with:",

--- a/tests/components/signup/signup_lti/__snapshots__/signup_lti.test.jsx.snap
+++ b/tests/components/signup/signup_lti/__snapshots__/signup_lti.test.jsx.snap
@@ -1,0 +1,399 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`components/signup/SignupLTI should match snapshot 1`] = `
+<div>
+  <BackButton
+    url="/"
+  />
+  <div
+    className="col-sm-12"
+  >
+    <div
+      className="signup-team__container padding--less"
+    >
+      <img
+        className="signup-team-logo"
+        src={null}
+      />
+      <SiteNameAndDescription
+        customDescriptionText=""
+        siteName="Mattermost"
+      />
+      <h4
+        className="color--light"
+      >
+        <FormattedMessage
+          defaultMessage="Let's create your account"
+          id="signup_user_completed.lets"
+          values={Object {}}
+        />
+      </h4>
+      <div
+        className="form-group has-error"
+      >
+        <label
+          className="control-label"
+        >
+          <FormattedMessage
+            defaultMessage="There was an error with your login request. Please try again or contact your system administrator."
+            id="signup_LTI.invalid_request"
+            values={Object {}}
+          />
+        </label>
+      </div>
+      <p>
+        <InjectIntl(FormattedMarkdownMessage)
+          defaultMessage="By proceeding to create your account and use {siteName}, you agree to our [Terms of Service]({TermsOfServiceLink}) and [Privacy Policy]({PrivacyPolicyLink}). If you do not agree, you cannot use {siteName}."
+          id="create_team.agreement"
+          values={
+            Object {
+              "PrivacyPolicyLink": "",
+              "TermsOfServiceLink": "",
+              "siteName": "Mattermost",
+            }
+          }
+        />
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/signup/SignupLTI should pick email, username and full name from state 1`] = `
+<div>
+  <BackButton
+    url="/"
+  />
+  <div
+    className="col-sm-12"
+  >
+    <div
+      className="signup-team__container padding--less"
+    >
+      <img
+        className="signup-team-logo"
+        src={null}
+      />
+      <SiteNameAndDescription
+        customDescriptionText=""
+        siteName="Mattermost"
+      />
+      <h4
+        className="color--light"
+      >
+        <FormattedMessage
+          defaultMessage="Let's create your account"
+          id="signup_user_completed.lets"
+          values={Object {}}
+        />
+      </h4>
+      <form>
+        <div
+          className="inner__content"
+        >
+          <div
+            className="margin--extra"
+          >
+            <h5>
+              <strong>
+                <FormattedMessage
+                  defaultMessage="Full Name"
+                  id="signup_LTI.fullname"
+                  values={Object {}}
+                />
+              </strong>
+            </h5>
+            <div
+              className="form-group"
+            >
+              <input
+                className="form-control"
+                defaultValue="Test User"
+                disabled={true}
+                id="fullname"
+                type="text"
+              />
+            </div>
+          </div>
+          <div
+            className="margin--extra"
+          >
+            <h5>
+              <strong>
+                <FormattedMessage
+                  defaultMessage="Username"
+                  id="signup_LTI.username"
+                  values={Object {}}
+                />
+              </strong>
+            </h5>
+            <div
+              className="form-group"
+            >
+              <input
+                className="form-control"
+                defaultValue="test"
+                disabled={true}
+                id="username"
+                type="text"
+              />
+            </div>
+          </div>
+          <div
+            className="margin--extra"
+          >
+            <h5>
+              <strong>
+                <FormattedMessage
+                  defaultMessage="Email Address"
+                  id="signup_LTI.email"
+                  values={Object {}}
+                />
+              </strong>
+            </h5>
+            <div
+              className="form-group"
+            >
+              <input
+                className="form-control"
+                defaultValue="test@nowhere.com"
+                disabled={true}
+                id="email"
+                type="email"
+              />
+            </div>
+          </div>
+          <InjectIntl(FormattedMarkdownMessage)
+            defaultMessage="Your email address is **{email}**. You'll use this address to sign in to {siteName}."
+            id="signup_user_completed.emailIs"
+            values={
+              Object {
+                "email": "test@nowhere.com",
+                "siteName": "Mattermost",
+              }
+            }
+          />
+          <div
+            className="margin--extra"
+          >
+            <h5>
+              <strong>
+                <FormattedMessage
+                  defaultMessage="Choose your password"
+                  id="signup_user_completed.choosePwd"
+                  values={Object {}}
+                />
+              </strong>
+            </h5>
+            <div
+              className="form-group"
+            >
+              <input
+                className="form-control"
+                id="password"
+                maxLength="128"
+                placeholder=""
+                spellCheck="false"
+                type="password"
+              />
+            </div>
+          </div>
+          <p
+            className="margin--extra"
+          >
+            <button
+              className="btn-primary btn"
+              disabled={false}
+              id="createAccountButton"
+              onClick={[Function]}
+              type="submit"
+            >
+              <FormattedMessage
+                defaultMessage="Create Account"
+                id="signup_user_completed.create"
+                values={Object {}}
+              />
+            </button>
+          </p>
+        </div>
+      </form>
+      <p>
+        <InjectIntl(FormattedMarkdownMessage)
+          defaultMessage="By proceeding to create your account and use {siteName}, you agree to our [Terms of Service]({TermsOfServiceLink}) and [Privacy Policy]({PrivacyPolicyLink}). If you do not agree, you cannot use {siteName}."
+          id="create_team.agreement"
+          values={
+            Object {
+              "PrivacyPolicyLink": "",
+              "TermsOfServiceLink": "",
+              "siteName": "Mattermost",
+            }
+          }
+        />
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`components/signup/SignupLTI should redirect to / when not signup with lti disabled 1`] = `
+<div>
+  <BackButton
+    url="/"
+  />
+  <div
+    className="col-sm-12"
+  >
+    <div
+      className="signup-team__container padding--less"
+    >
+      <img
+        className="signup-team-logo"
+        src={null}
+      />
+      <SiteNameAndDescription
+        customDescriptionText=""
+        siteName="Mattermost"
+      />
+      <h4
+        className="color--light"
+      >
+        <FormattedMessage
+          defaultMessage="Let's create your account"
+          id="signup_user_completed.lets"
+          values={Object {}}
+        />
+      </h4>
+      <form>
+        <div
+          className="inner__content"
+        >
+          <div
+            className="margin--extra"
+          >
+            <h5>
+              <strong>
+                <FormattedMessage
+                  defaultMessage="Full Name"
+                  id="signup_LTI.fullname"
+                  values={Object {}}
+                />
+              </strong>
+            </h5>
+            <div
+              className="form-group"
+            >
+              <input
+                className="form-control"
+                disabled={true}
+                id="fullname"
+                type="text"
+              />
+            </div>
+          </div>
+          <div
+            className="margin--extra"
+          >
+            <h5>
+              <strong>
+                <FormattedMessage
+                  defaultMessage="Username"
+                  id="signup_LTI.username"
+                  values={Object {}}
+                />
+              </strong>
+            </h5>
+            <div
+              className="form-group"
+            >
+              <input
+                className="form-control"
+                disabled={true}
+                id="username"
+                type="text"
+              />
+            </div>
+          </div>
+          <div
+            className="margin--extra"
+          >
+            <h5>
+              <strong>
+                <FormattedMessage
+                  defaultMessage="Email Address"
+                  id="signup_LTI.email"
+                  values={Object {}}
+                />
+              </strong>
+            </h5>
+            <div
+              className="form-group"
+            >
+              <input
+                className="form-control"
+                disabled={true}
+                id="email"
+                type="email"
+              />
+            </div>
+          </div>
+          <div
+            className="margin--extra"
+          >
+            <h5>
+              <strong>
+                <FormattedMessage
+                  defaultMessage="Choose your password"
+                  id="signup_user_completed.choosePwd"
+                  values={Object {}}
+                />
+              </strong>
+            </h5>
+            <div
+              className="form-group"
+            >
+              <input
+                className="form-control"
+                id="password"
+                maxLength="128"
+                placeholder=""
+                spellCheck="false"
+                type="password"
+              />
+            </div>
+          </div>
+          <p
+            className="margin--extra"
+          >
+            <button
+              className="btn-primary btn"
+              disabled={false}
+              id="createAccountButton"
+              onClick={[Function]}
+              type="submit"
+            >
+              <FormattedMessage
+                defaultMessage="Create Account"
+                id="signup_user_completed.create"
+                values={Object {}}
+              />
+            </button>
+          </p>
+        </div>
+      </form>
+      <p>
+        <InjectIntl(FormattedMarkdownMessage)
+          defaultMessage="By proceeding to create your account and use {siteName}, you agree to our [Terms of Service]({TermsOfServiceLink}) and [Privacy Policy]({PrivacyPolicyLink}). If you do not agree, you cannot use {siteName}."
+          id="create_team.agreement"
+          values={
+            Object {
+              "PrivacyPolicyLink": "",
+              "TermsOfServiceLink": "",
+              "siteName": "Mattermost",
+            }
+          }
+        />
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/tests/components/signup/signup_lti/signup_lti.test.jsx
+++ b/tests/components/signup/signup_lti/signup_lti.test.jsx
@@ -1,0 +1,77 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {shallow} from 'enzyme';
+
+import SignupLTI from 'components/signup/signup_lti/signup_lti.jsx';
+
+describe('components/signup/SignupLTI', () => {
+    const baseProps = {
+        customDescriptionText: '',
+        actions: {
+            createLTIUser: jest.fn(),
+        },
+        enableSignUpWithLTI: true,
+        passwordConfig: {
+            minimumLength: 4,
+            requireLowercase: false,
+            requireUppercase: false,
+            requireNumber: false,
+            requireSymbol: false,
+        },
+        privacyPolicyLink: '',
+        siteName: 'Mattermost',
+        termsOfServiceLink: '',
+    };
+
+    test('should match snapshot', () => {
+        const wrapper = shallow(
+            <SignupLTI {...baseProps}/>
+        );
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should redirect to / when not signup with lti disabled', () => {
+        const props = {
+            ...baseProps,
+            enableSignUpWithLTI: false,
+        };
+        const wrapper = shallow(
+            <SignupLTI {...props}/>
+        );
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should pick email, username and full name from state', () => {
+        const props = {
+            ...baseProps,
+            enableSignUpWithLTI: false,
+        };
+        const wrapper = shallow(
+            <SignupLTI {...props}/>
+        );
+        wrapper.setState({
+            formData: {
+                lis_person_contact_email_primary: 'test@nowhere.com',
+                lis_person_name_full: 'Test User',
+                lis_person_sourcedid: 'test',
+            },
+        });
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    test('should have match state and make API call when handleSubmit is called', () => {
+        const wrapper = shallow(
+            <SignupLTI {...baseProps}/>
+        );
+
+        wrapper.instance().refs = {password: {value: 'password'}};
+        wrapper.setState({serverError: '', isSubmitting: false});
+        wrapper.instance().handleSubmit({preventDefault: jest.fn()});
+        expect(wrapper.state('serverError')).toEqual('');
+        expect(wrapper.state('isSubmitting')).toEqual(true);
+        expect(baseProps.actions.createLTIUser).toBeCalled();
+    });
+});


### PR DESCRIPTION
#### Summary
- Delete the LTI launch data cookie on Signup success.
- Redirect to the required channel on signup success.
- Add test cases for LTI signup.

#### Note
Please update the `package.json` with the redux commit when the redux PR (https://github.com/rifflearning/mattermost-redux/pull/3) is merged and run `npm i` to update `package-lock.json` file. 

#### Checklist
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
- [x] Has server changes (https://github.com/rifflearning/mattermost-server/pull/10)
- [x] Has redux changes (https://github.com/rifflearning/mattermost-redux/pull/3)
- [x] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [x] Touches critical sections of the codebase (auth, posting, etc.)
