### PR TITLE
Fix color strip on bottom of PeerVideos

### DIFF
--- a/components/webrtc_view_bulma/PeerVideo.jsx
+++ b/components/webrtc_view_bulma/PeerVideo.jsx
@@ -1,67 +1,70 @@
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 import React from 'react';
-import { logger } from '../../utils/riff';
-import * as sc from './styled';
+
+import {logger} from '../../utils/riff';
 
 class PeerVideo extends React.Component {
-    constructor (props) {
+    constructor(props) {
         super(props);
         this.appendVideo = this.appendVideo.bind(this);
         this.video = this.props.videoEl;
     }
 
-    appendVideo (el) {
-      logger.debug("appending?", "color:", this.props.peerColor)
-      if (el !== null) {
-          this.video.style.setProperty('overflow', 'hidden');
-          this.video.style.setProperty('display', 'block');
-          this.video.style.setProperty('width', '100%');
-          this.video.style.setProperty('height', '100%');
-          this.video.style.setProperty('margins', '5px');
-          this.video.style.setProperty('border-radius', '5px');
-          if (this.props.type === "peer") {
-              // we don't want to clip any of the shared screen,
-              // so only apply this to peers
-              this.video.style.setProperty('object-fit', 'cover');
-              this.video.style.setProperty('border-bottom-right-radius', '0px');
-              this.video.style.setProperty('border-bottom-left-radius', '0px');
-          }
-          el.appendChild(this.video);
-          this.video.play()
-      }
+    appendVideo(el) {
+        logger.debug('appending?', 'color:', this.props.peerColor);
+        if (el !== null) {
+            this.video.style.setProperty('overflow', 'hidden');
+            this.video.style.setProperty('display', 'block');
+            this.video.style.setProperty('width', '100%');
+            this.video.style.setProperty('height', '100%');
+            this.video.style.setProperty('margins', '5px');
+            this.video.style.setProperty('border-radius', '5px');
+            if (this.props.type === 'peer') {
+                // we don't want to clip any of the shared screen,
+                // so only apply this to peers
+                this.video.style.setProperty('object-fit', 'cover');
+                this.video.style.setProperty('border-bottom-right-radius', '0px');
+                this.video.style.setProperty('border-bottom-left-radius', '0px');
+            }
+            el.appendChild(this.video);
+            this.video.play();
+        }
     }
 
-    render () {
-      let style = {
-          'padding': '0.25rem',
-      };
+    render() {
+        const style = {
+            padding: '0.25rem',
+        };
 
-      if (this.props.type === "peer") {
-          style.borderBottom = '5px solid ' + this.props.peerColor;
-          style.padding = '0';
-          style.margin = '0.25rem';
-          style.borderBottomRightRadius = '5px';
-          style.borderBottomLeftRadius = '5px';
-      }
+        if (this.props.type === 'peer') {
+            style.borderBottom = '5px solid ' + this.props.peerColor;
+            style.padding = '0';
+            style.margin = '0.25rem';
+            style.borderBottomRightRadius = '5px';
+            style.borderBottomLeftRadius = '5px';
+        }
 
-      let classes = "videoContainer remotes column";
+        let classes = 'videoContainer remotes column';
 
-      if (this.props.peerLength < 4) {
-          style.width = '100vh';
-          style.height = '80vh';
-      } else {
-          style.width = '50vh';
-          style.height = '40vh';
-          classes += " is-narrow";
-      }
+        if (this.props.peerLength < 4) {
+            style.width = '100vh';
+            style.height = '80vh';
+        } else {
+            style.width = '50vh';
+            style.height = '40vh';
+            classes += ' is-narrow';
+        }
 
-      return (
-        <div
-            className={classes}
-            id={"container_" + this.props.id}
-            style={style}
-            ref={this.appendVideo}
-        />
-      );
+        return (
+            <div
+                className={classes}
+                id={'container_' + this.props.id}
+                style={style}
+                ref={this.appendVideo}
+            />
+        );
     }
 }
 

--- a/components/webrtc_view_bulma/PeerVideo.jsx
+++ b/components/webrtc_view_bulma/PeerVideo.jsx
@@ -22,7 +22,8 @@ class PeerVideo extends React.Component {
           // we don't want to clip any of the shared screen,
           // so only apply this to peers
           this.video.style.setProperty('object-fit', 'cover');
-          this.video.style.setProperty('border-bottom', '5px solid ' + this.props.peerColor);
+          this.video.style.setProperty('border-bottom-right-radius', '0px');
+          this.video.style.setProperty('border-bottom-left-radius', '0px');
         }
         el.appendChild(this.video);
         this.video.play()
@@ -35,7 +36,11 @@ class PeerVideo extends React.Component {
       };
 
       if (this.props.type === "peer") {
-        style.borderBottom = '5px solid ' + this.props.PeerColor;
+        style.borderBottom = '5px solid ' + this.props.peerColor;
+        style.padding = '0';
+        style.margin = '0.25rem';
+        style.borderBottomRightRadius = '5px';
+        style.borderBottomLeftRadius = '5px';
       }
 
       let classes = "videoContainer remotes column";

--- a/components/webrtc_view_bulma/PeerVideo.jsx
+++ b/components/webrtc_view_bulma/PeerVideo.jsx
@@ -12,54 +12,54 @@ class PeerVideo extends React.Component {
     appendVideo (el) {
       logger.debug("appending?", "color:", this.props.peerColor)
       if (el !== null) {
-        this.video.style.setProperty('overflow', 'hidden');
-        this.video.style.setProperty('display', 'block');
-        this.video.style.setProperty('width', '100%');
-        this.video.style.setProperty('height', '100%');
-        this.video.style.setProperty('margins', '5px');
-        this.video.style.setProperty('border-radius', '5px');
-        if (this.props.type === "peer") {
-          // we don't want to clip any of the shared screen,
-          // so only apply this to peers
-          this.video.style.setProperty('object-fit', 'cover');
-          this.video.style.setProperty('border-bottom-right-radius', '0px');
-          this.video.style.setProperty('border-bottom-left-radius', '0px');
-        }
-        el.appendChild(this.video);
-        this.video.play()
+          this.video.style.setProperty('overflow', 'hidden');
+          this.video.style.setProperty('display', 'block');
+          this.video.style.setProperty('width', '100%');
+          this.video.style.setProperty('height', '100%');
+          this.video.style.setProperty('margins', '5px');
+          this.video.style.setProperty('border-radius', '5px');
+          if (this.props.type === "peer") {
+              // we don't want to clip any of the shared screen,
+              // so only apply this to peers
+              this.video.style.setProperty('object-fit', 'cover');
+              this.video.style.setProperty('border-bottom-right-radius', '0px');
+              this.video.style.setProperty('border-bottom-left-radius', '0px');
+          }
+          el.appendChild(this.video);
+          this.video.play()
       }
     }
 
     render () {
       let style = {
-        'padding': '0.25rem',
+          'padding': '0.25rem',
       };
 
       if (this.props.type === "peer") {
-        style.borderBottom = '5px solid ' + this.props.peerColor;
-        style.padding = '0';
-        style.margin = '0.25rem';
-        style.borderBottomRightRadius = '5px';
-        style.borderBottomLeftRadius = '5px';
+          style.borderBottom = '5px solid ' + this.props.peerColor;
+          style.padding = '0';
+          style.margin = '0.25rem';
+          style.borderBottomRightRadius = '5px';
+          style.borderBottomLeftRadius = '5px';
       }
 
       let classes = "videoContainer remotes column";
 
       if (this.props.peerLength < 4) {
-        style.width = '100vh';
-        style.height = '80vh';
+          style.width = '100vh';
+          style.height = '80vh';
       } else {
-        style.width = '50vh';
-        style.height = '40vh';
-        classes += " is-narrow";
+          style.width = '50vh';
+          style.height = '40vh';
+          classes += " is-narrow";
       }
 
       return (
         <div
-          className={classes}
-          id={"container_" + this.props.id}
-          style={style}
-          ref={this.appendVideo}
+            className={classes}
+            id={"container_" + this.props.id}
+            style={style}
+            ref={this.appendVideo}
         />
       );
     }

--- a/components/webrtc_view_bulma/RemoteVideoContainer.jsx
+++ b/components/webrtc_view_bulma/RemoteVideoContainer.jsx
@@ -15,22 +15,22 @@ class RemoteVideoContainer extends React.Component {
         // returns a function
         // close over peerLength
         return function (peer) {
-          let [riffId, displayName] = peer.nick.split("|");
-          let riffIds = [...this.props.chat.webRtcRiffIds].sort();
-          logger.debug("riff ids:", riffIds);
-          const idx = riffIds.indexOf(riffId);
-          let peerColor = this.props.chat.peerColors[idx];
-          logger.debug("!!PEER COLOR:", peerColor, "IDX:", idx, "Riff ID:", riffId);
-          return (
-            <PeerVideo
-              key={peer.id}
-              id={peer.id}
-              videoEl={peer.videoEl}
-              type="peer"
-              peerColor={peerColor}
-              peerLength={peerLength}
-            />
-          );
+            const [riffId, displayName] = peer.nick.split("|");
+            const riffIds = [...this.props.chat.webRtcRiffIds].sort();
+            logger.debug("riff ids:", riffIds);
+            const idx = riffIds.indexOf(riffId);
+            const peerColor = this.props.chat.peerColors[idx];
+            logger.debug("!!PEER COLOR:", peerColor, "IDX:", idx, "Riff ID:", riffId);
+            return (
+                <PeerVideo
+                  key={peer.id}
+                  id={peer.id}
+                  videoEl={peer.videoEl}
+                  type="peer"
+                  peerColor={peerColor}
+                  peerLength={peerLength}
+                />
+            );
         }.bind(this)
     }
 

--- a/components/webrtc_view_bulma/RemoteVideoContainer.jsx
+++ b/components/webrtc_view_bulma/RemoteVideoContainer.jsx
@@ -1,71 +1,72 @@
-import React from 'react';
-import * as sc from './styled';
-import SharedScreen from './SharedScreen'
-import PeerVideo from './PeerVideo'
-import { logger } from '../../utils/riff';
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
 
+import React from 'react';
+
+import {logger} from '../../utils/riff';
+
+import SharedScreen from './SharedScreen';
+import PeerVideo from './PeerVideo';
 
 class RemoteVideoContainer extends React.Component {
     constructor(props) {
         super(props);
-        console.log("remote video props:", props);
+        logger.debug('remote video props:', props);
     }
 
     peerVideo(peerLength) {
         // returns a function
         // close over peerLength
-        return function (peer) {
-            const [riffId, displayName] = peer.nick.split("|");
+        return (peer) => {
+            const [riffId, displayName] = peer.nick.split('|'); // eslint-disable-line no-unused-vars
             const riffIds = [...this.props.chat.webRtcRiffIds].sort();
-            logger.debug("riff ids:", riffIds);
+            logger.debug('riff ids:', riffIds);
             const idx = riffIds.indexOf(riffId);
             const peerColor = this.props.chat.peerColors[idx];
-            logger.debug("!!PEER COLOR:", peerColor, "IDX:", idx, "Riff ID:", riffId);
+            logger.debug('!!PEER COLOR:', peerColor, 'IDX:', idx, 'Riff ID:', riffId);
             return (
                 <PeerVideo
-                  key={peer.id}
-                  id={peer.id}
-                  videoEl={peer.videoEl}
-                  type="peer"
-                  peerColor={peerColor}
-                  peerLength={peerLength}
+                    key={peer.id}
+                    id={peer.id}
+                    videoEl={peer.videoEl}
+                    type="peer"
+                    peerColor={peerColor}
+                    peerLength={peerLength}
                 />
             );
-        }.bind(this)
+        };
     }
 
     addPeerVideos() {
-        let peerLength = this.props.peers.length;
-        logger.debug("rendering", peerLength, "peers....", this.props.peers);
-        logger.debug("names:", this.props.chat.webRtcPeerDisplayNames);
-        logger.debug("riff ids:", this.props.chat.webRtcRiffIds);
+        const peerLength = this.props.peers.length;
+        logger.debug('rendering', peerLength, 'peers....', this.props.peers);
+        logger.debug('names:', this.props.chat.webRtcPeerDisplayNames);
+        logger.debug('riff ids:', this.props.chat.webRtcRiffIds);
         return this.props.peers.map(this.peerVideo(peerLength));
     }
 
     videos() {
         if (this.props.remoteSharedScreen) {
-          return (
-            <SharedScreen
-              videoEl={this.props.remoteSharedScreen}
-              peers={this.props.peers}
-            />
-          );
-        } else {
-          return this.addPeerVideos();
+            return (
+                <SharedScreen
+                    videoEl={this.props.remoteSharedScreen}
+                    peers={this.props.peers}
+                />
+            );
         }
-    };
 
+        return this.addPeerVideos();
+    }
 
     render() {
         return (
-            <div className = "remotes" id = "remoteVideos">
-              <div ref = "remotes" className = "columns is-multiline is-centered is-mobile">
-                {this.videos()}
-              </div>
+            <div className="remotes" id="remoteVideos">
+                <div ref="remotes" className="columns is-multiline is-centered is-mobile">
+                    {this.videos()}
+                </div>
             </div>
         );
     }
-
 }
 
 export default RemoteVideoContainer;

--- a/components/webrtc_view_bulma/RemoteVideoContainer.jsx
+++ b/components/webrtc_view_bulma/RemoteVideoContainer.jsx
@@ -16,7 +16,7 @@ class RemoteVideoContainer extends React.Component {
         // close over peerLength
         return function (peer) {
           let [riffId, displayName] = peer.nick.split("|");
-          let riffIds = this.props.chat.webRtcRiffIds.sort();
+          let riffIds = [...this.props.chat.webRtcRiffIds].sort();
           logger.debug("riff ids:", riffIds);
           const idx = riffIds.indexOf(riffId);
           let peerColor = this.props.chat.peerColors[idx];

--- a/utils/webrtc/webrtc.js
+++ b/utils/webrtc/webrtc.js
@@ -1,14 +1,17 @@
 import SimpleWebRtc from 'simplewebrtc';
-import * as WebRtcActions from '../../actions/webrtc_actions';
-import sibilant from 'sibilant-webaudio';
-import { app, socket } from '../riff';
-import {updateRiffMeetingId} from '../../actions/views/riff';
-import parse from 'url-parse';
-import { logger } from '../riff';
 
+import sibilant from 'sibilant-webaudio';
+
+import parse from 'url-parse';
+
+import * as WebRtcActions from '../../actions/webrtc_actions';
+
+import {app, logger} from '../riff';
+
+import {updateRiffMeetingId} from '../../actions/views/riff';
 
 export const createWebRtcLink = (teamName, channelName) => {
-    let link = parse(window.location.href, true);
+    const link = parse(window.location.href, true);
     link.set('pathname', teamName + '/' + channelName + '/' + 'video' + '/' + generateUID());
     console.log("Created webrtc Link:", link.href);
     return link;
@@ -26,11 +29,11 @@ function generateUID() {
 
 
 export function isScreenShareSourceAvailable() {
-  // currently we only support chrome v70+ (w/ experimental features enabled, if necessary)
-  // and firefox
-  return (navigator.getDisplayMedia ||
-    navigator.mediaDevices.getDisplayMedia ||
-    !!navigator.mediaDevices.getSupportedConstraints().mediaSource);
+    // currently we only support chrome v70+ (w/ experimental features enabled, if necessary)
+    // and firefox
+    return (navigator.getDisplayMedia ||
+        navigator.mediaDevices.getDisplayMedia ||
+        !!navigator.mediaDevices.getSupportedConstraints().mediaSource);
 }
 
 export default function (localVideoNode, dispatch, getState) {
@@ -38,7 +41,7 @@ export default function (localVideoNode, dispatch, getState) {
     let signalmasterPath = process.env.CLIENT_ENV.SIGNALMASTER_PATH || '';
     signalmasterPath += '/socket.io';
     let signalmasterUrl = process.env.CLIENT_ENV.SIGNALMASTER_URL;
-    let webRtcConfig = {
+    const webRtcConfig = {
         localVideoEl: localVideoNode,
         remoteVideosEl: "",
         autoRequestMedia: true,
@@ -67,12 +70,12 @@ export default function (localVideoNode, dispatch, getState) {
     });
 
     webrtc.on('videoRemoved', function (video, peer) {
-        let state = getState();
+        const state = getState();
         // get riffId
         if (state.views.webrtc.inRoom) {
             dispatch(WebRtcActions.removePeer({peer: peer,
                                                videoEl: video}));
-            let [riffId, ...rest] = peer.nick.split("|");
+            const [riffId, ...rest] = peer.nick.split("|");
             //TODO: state get here is wrong.
             dispatch(WebRtcActions.riffParticipantLeaveRoom(state.views.riff.meetingId, riffId));
         }
@@ -127,7 +130,7 @@ export default function (localVideoNode, dispatch, getState) {
 
             webrtc.startVolumeCollection = function () {
                 sib.bind('volumeChange', function (data) {
-                    let state = getState();
+                    const state = getState();
                     if (!state.views.webrtc.inRoom) {
                         dispatch(WebRtcActions.volumeChanged(data));
                     }

--- a/utils/webrtc/webrtc.js
+++ b/utils/webrtc/webrtc.js
@@ -1,140 +1,139 @@
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 import SimpleWebRtc from 'simplewebrtc';
-
-import sibilant from 'sibilant-webaudio';
-
+import Sibilant from 'sibilant-webaudio';
 import parse from 'url-parse';
 
 import * as WebRtcActions from '../../actions/webrtc_actions';
-
-import {app, logger} from '../riff';
-
 import {updateRiffMeetingId} from '../../actions/views/riff';
+import {app, logger} from '../riff';
 
 export const createWebRtcLink = (teamName, channelName) => {
     const link = parse(window.location.href, true);
-    link.set('pathname', teamName + '/' + channelName + '/' + 'video' + '/' + generateUID());
-    console.log("Created webrtc Link:", link.href);
+    link.set('pathname', `${teamName}/${channelName}/video/${generateUID()}`);
+    logger.debug('Created webrtc Link:', link.href);
     return link;
-}
+};
 
 function generateUID() {
     // I generate the UID from two parts here
     // to ensure the random number provide enough bits.
     var firstPart = (Math.random() * 46656) | 0;
     var secondPart = (Math.random() * 46656) | 0;
-    firstPart = ("000" + firstPart.toString(36)).slice(-3);
-    secondPart = ("000" + secondPart.toString(36)).slice(-3);
+    firstPart = ('000' + firstPart.toString(36)).slice(-3);
+    secondPart = ('000' + secondPart.toString(36)).slice(-3);
     return firstPart + secondPart;
 }
-
 
 export function isScreenShareSourceAvailable() {
     // currently we only support chrome v70+ (w/ experimental features enabled, if necessary)
     // and firefox
     return (navigator.getDisplayMedia ||
         navigator.mediaDevices.getDisplayMedia ||
-        !!navigator.mediaDevices.getSupportedConstraints().mediaSource);
+        Boolean(navigator.mediaDevices.getSupportedConstraints().mediaSource));
 }
 
 export default function (localVideoNode, dispatch, getState) {
     //TODO: make dynamic
     let signalmasterPath = process.env.CLIENT_ENV.SIGNALMASTER_PATH || '';
     signalmasterPath += '/socket.io';
-    let signalmasterUrl = process.env.CLIENT_ENV.SIGNALMASTER_URL;
+    const signalmasterUrl = process.env.CLIENT_ENV.SIGNALMASTER_URL;
     const webRtcConfig = {
         localVideoEl: localVideoNode,
-        remoteVideosEl: "",
+        remoteVideosEl: '',
         autoRequestMedia: true,
         url: signalmasterUrl,
         socketio: {
             path: signalmasterPath,
-            forceNew: true
+            forceNew: true,
         },
         media: {
             audio: true,
             video: {
                 width: {ideal: 640},
                 height: {ideal: 480},
-                frameRate: {max: 30}
-            }
+                frameRate: {max: 30},
+            },
         },
-        debug: true
+        debug: true,
     };
 
     const webrtc = new SimpleWebRtc(webRtcConfig);
 
-
-    webrtc.on('videoAdded', function (video, peer) {
-        console.log("added video", video, peer);
+    webrtc.on('videoAdded', (video, peer) => {
+        logger.debug('added video', video, peer);
         dispatch(WebRtcActions.addPeer({peer}));
     });
 
-    webrtc.on('videoRemoved', function (video, peer) {
+    webrtc.on('videoRemoved', (video, peer) => {
         const state = getState();
+
         // get riffId
         if (state.views.webrtc.inRoom) {
-            dispatch(WebRtcActions.removePeer({peer: peer,
-                                               videoEl: video}));
-            const [riffId, ...rest] = peer.nick.split("|");
+            dispatch(WebRtcActions.removePeer({peer,
+                                               videoEl: video})); // eslint-disable-line indent
+            const [riffId, ...rest] = peer.nick.split('|'); // eslint-disable-line no-unused-vars
+
             //TODO: state get here is wrong.
             dispatch(WebRtcActions.riffParticipantLeaveRoom(state.views.riff.meetingId, riffId));
         }
     });
 
-    webrtc.on('screenAdded', function (video, peer) {
-        logger.debug("adding shared screen!", video, "from", peer);
-        dispatch(WebRtcActions.addSharedScreen({ videoEl: video, peer: peer }));
+    webrtc.on('screenAdded', (video, peer) => {
+        logger.debug('adding shared screen!', video, 'from', peer);
+        dispatch(WebRtcActions.addSharedScreen({videoEl: video, peer}));
     });
 
-    webrtc.on('screenRemoved', function (video, peer) {
-        logger.debug("removing shared screen!", video);
+    webrtc.on('screenRemoved', (video) => {
+        logger.debug('removing shared screen!', video);
         dispatch(WebRtcActions.removeSharedScreen());
     });
 
-    webrtc.on('localScreenAdded', function (video) {
+    webrtc.on('localScreenAdded', (video) => {
         dispatch(WebRtcActions.addLocalSharedScreen(video));
     });
 
-    webrtc.on('localScreenRemoved', function (video) {
+    webrtc.on('localScreenRemoved', (video) => {
         dispatch(WebRtcActions.removeLocalSharedScreen(video));
     });
 
     // this happens if the user ends via the chrome button
     // instead of our button
-    webrtc.on('localScreenStopped', function (video) {
+    webrtc.on('localScreenStopped', (video) => {
         dispatch(WebRtcActions.removeLocalSharedScreen(video));
     });
 
-    webrtc.on('localScreenRequestFailed', function () {
+    webrtc.on('localScreenRequestFailed', () => {
         dispatch(WebRtcActions.getDisplayError());
     });
 
-    webrtc.on('localStreamRequestFailed', function (event) {
+    webrtc.on('localStreamRequestFailed', (event) => {
         dispatch(WebRtcActions.getMediaError(event));
     });
 
-    webrtc.on('localStream', function (stream) {
+    webrtc.on('localStream', (stream) => {
         if (stream.active) {
             dispatch(WebRtcActions.getMediaSuccess());
         }
     });
 
-    webrtc.on('readyToCall', function (video, peer) {
-        let stream = webrtc.webrtc.localStreams[0];
+    webrtc.on('readyToCall', (/*video, peer*/) => {
+        const stream = webrtc.webrtc.localStreams[0];
         dispatch(WebRtcActions.getMediaSuccess());
-        var sib = new sibilant(stream);
+        const sib = new Sibilant(stream);
         if (sib) {
-            webrtc.stopVolumeCollection = function () {
+            webrtc.stopVolumeCollection = () => {
                 // sib.unbind('volumeChange');
             };
 
-            webrtc.startVolumeCollection = function () {
-                sib.bind('volumeChange', function (data) {
+            webrtc.startVolumeCollection = () => {
+                sib.bind('volumeChange', (data) => {
                     const state = getState();
                     if (!state.views.webrtc.inRoom) {
                         dispatch(WebRtcActions.volumeChanged(data));
                     }
-                }.bind(getState));
+                });
             };
 
             webrtc.startVolumeCollection();
@@ -146,16 +145,15 @@ export default function (localVideoNode, dispatch, getState) {
                 room: getState().views.webrtc.roomName,
                 startTime: data.start.toISOString(),
                 endTime: data.end.toISOString(),
-                token: getState().views.riff.authToken
-            }).then(function (res) {
+                token: getState().views.riff.authToken,
+            }).then((res) => {
                 dispatch(updateRiffMeetingId(res.meeting));
-            }).catch(function (err) {
+            }).catch((err) => { // eslint-disable-line no-unused-vars
                 // error thrown, throw it?
             });
         });
 
-
-        webrtc.stopSibilant = function () {
+        webrtc.stopSibilant = () => {
             sib.unbind('volumeChange');
             sib.unbind('stoppedSpeaking');
         };
@@ -170,4 +168,5 @@ export default function (localVideoNode, dispatch, getState) {
     };
 
     return webrtc;
-};
+}
+


### PR DESCRIPTION
#### Summary
The right color strips are now displayed under each `<PeerVideo />` and they correspond to the color map. 

#### Ticket Link
https://trello.com/c/N5LdQTxV/203-meeting-mediator-color-map-broken

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [x] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
