### PR TITLE
Fix flickering icon on the Riff Stats tab in the sidebar

### DIFF
--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -93,12 +93,17 @@ export default class Sidebar extends React.PureComponent {
         unreadChannelIds: PropTypes.array.isRequired,
 
         /**
+         * Current page name
+         */
+        currentPage: PropTypes.string,
+
+        /**
          * Current channel object
          */
         currentChannel: PropTypes.object,
 
         /**
-         * Current channel teammeat (for direct messages)
+         * Current channel teammate (for direct messages)
          */
         currentTeammate: PropTypes.object,
 
@@ -530,8 +535,10 @@ export default class Sidebar extends React.PureComponent {
         );
 
         var dashboard = (
-            <li key='dashboard'
-                className={this.props.currentPage === 'dashboard' ? 'active' : ''}>
+            <li
+                key='dashboard'
+                className={this.props.currentPage === 'dashboard' ? 'active' : ''}
+            >
                 <button
                     id='dashboard'
                     className='nav-more cursor--pointer style--none btn--block'
@@ -543,20 +550,26 @@ export default class Sidebar extends React.PureComponent {
                 >
 
                     <span style={{marginRight: '.5rem'}}>
-                        <svg xmlns='http://www.w3.org/2000/svg'
-                             width='17'
-                             height='17'
-                             viewBox='0 0 24 24'>
-                                 <path d='M0 0h24v24H0z'
-                                       fill='none'/>
-                                 <path d='M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z'
-                                       fill='#ffffff'/>
+                        <svg
+                            xmlns='http://www.w3.org/2000/svg'
+                            width='17'
+                            height='17'
+                            viewBox='0 0 24 24'
+                        >
+                            <path
+                                d='M0 0h24v24H0z'
+                                fill='none'
+                            />
+                            <path
+                                d='M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z'
+                                fill='#ffffff'
+                            />
                         </svg>
                     </span>
                     <FormattedMessage
                         id='sidebar.dashboard'
-                        defaultMessage='Riff Stats'>
-                    </FormattedMessage>
+                        defaultMessage='Riff Stats'
+                    />
                 </button>
             </li>
         );
@@ -804,12 +817,13 @@ export default class Sidebar extends React.PureComponent {
                                 {favoriteItems}
                             </ul>}
                             <ul className='nav nav-pills nav-stacked'>
-
                                 <li>
-                                  <h4 id='dashboard'>
-                                    <FormattedMessage id='sidebar.dashboard'
-                                                      defaultMessage='DASHBOARD'/>
-                                  </h4>
+                                    <h4 id='dashboard'>
+                                        <FormattedMessage
+                                            id='sidebar.dashboard'
+                                            defaultMessage='DASHBOARD'
+                                        />
+                                    </h4>
                                 </li>
                                 {dashboard}
                                 <li>

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -9,7 +9,6 @@ import {FormattedMessage} from 'react-intl';
 import {PropTypes} from 'prop-types';
 import Permissions from 'mattermost-redux/constants/permissions';
 import classNames from 'classnames';
-import {Link} from 'react-router-dom';
 
 import Scrollbars from 'react-custom-scrollbars';
 
@@ -27,7 +26,6 @@ import MoreChannels from 'components/more_channels';
 import MoreDirectChannels from 'components/more_direct_channels';
 import TeamPermissionGate from 'components/permissions_gates/team_permission_gate';
 import Pluggable from 'plugins/pluggable';
-import MaterialIcon from 'material-icons-react';
 
 import NewChannelFlow from '../new_channel_flow.jsx';
 import UnreadChannelIndicator from '../unread_channel_indicator.jsx';
@@ -532,24 +530,32 @@ export default class Sidebar extends React.PureComponent {
         );
 
         var dashboard = (
-            <li key='dashboard' className={this.props.currentPage === 'dashboard' ? 'active' : ''}>
+            <li key='dashboard'
+                className={this.props.currentPage === 'dashboard' ? 'active' : ''}>
                 <button
                     id='dashboard'
                     className='nav-more cursor--pointer style--none btn--block'
                     onClick={
                         () => {
-                            browserHistory.push(`/${this.props.currentTeam.name}/pages/dashboard`)
+                            browserHistory.push(`/${this.props.currentTeam.name}/pages/dashboard`);
                         }
                     }
                 >
 
-                  <span style={{marginRight: ".5rem"}}>
-                    <MaterialIcon icon="dashboard" size={17} invert/>
-                  </span>
+                    <span style={{marginRight: '.5rem'}}>
+                        <svg xmlns='http://www.w3.org/2000/svg'
+                             width='17'
+                             height='17'
+                             viewBox='0 0 24 24'>
+                                 <path d='M0 0h24v24H0z'
+                                       fill='none'/>
+                                 <path d='M3 13h8V3H3v10zm0 8h8v-6H3v6zm10 0h8V11h-8v10zm0-18v6h8V3h-8z'
+                                       fill='#ffffff'/>
+                        </svg>
+                    </span>
                     <FormattedMessage
                         id='sidebar.dashboard'
-                        defaultMessage='Riff Stats'
-                      >
+                        defaultMessage='Riff Stats'>
                     </FormattedMessage>
                 </button>
             </li>
@@ -800,9 +806,9 @@ export default class Sidebar extends React.PureComponent {
                             <ul className='nav nav-pills nav-stacked'>
 
                                 <li>
-                                  <h4 id="dashboard">
-                                    <FormattedMessage id="sidebar.dashboard"
-                                                      defaultMessage="DASHBOARD"/>
+                                  <h4 id='dashboard'>
+                                    <FormattedMessage id='sidebar.dashboard'
+                                                      defaultMessage='DASHBOARD'/>
                                   </h4>
                                 </li>
                                 {dashboard}


### PR DESCRIPTION
#### Summary
The `<MaterialIcon />`, when re-rendering, briefly flickers while the browser reloads the font library. I replaced the `<MaterialIcon />` with an svg, which does not flicker on re-render.

Fixed check-style errors in relevant files, and reduced problems from 4507 to 4486.

#### Ticket Link
https://trello.com/c/0vwBKGAV/215-dashboard-navigation-flicker

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes

