### PR TITLE
Fix  MeetingViz proptypes

### DIFF
--- a/components/dashboard/components/MeetingViz.jsx
+++ b/components/dashboard/components/MeetingViz.jsx
@@ -100,15 +100,18 @@ class MeetingViz extends React.PureComponent {
     static propTypes = {
         user: PropTypes.object.isRequired,
         allMeetings: PropTypes.array.isRequired,
-        size: PropTypes.exact({
-            height: PropTypes.number.isRequired,
-            width: PropTypes.number.isRequired,
+        size: PropTypes.shape({
+            height: PropTypes.number,
+            width: PropTypes.number,
         }),
         loaded: PropTypes.bool.isRequired,
         meeting: PropTypes.object.isRequired,
         selectedMeetingDuration: PropTypes.string,
         processedUtterances: PropTypes.array.isRequired,
-        influenceData: PropTypes.object.isRequired,
+        influenceData: PropTypes.oneOfType([
+            PropTypes.array,
+            PropTypes.object,
+        ]),
         timelineData: PropTypes.object.isRequired,
 
         loadMeetingData: PropTypes.func.isRequired,


### PR DESCRIPTION
#### Summary
The properties I added to the MeetingViz propTypes were not correct. They were my best guess
but I got errors in the console when running which informed me what those types should be.
This PR sets better types for `size` and `influenceData`

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ x] Ran `make check-style` to check for style errors (required for all pull requests)
