### PR TITLE
Generated Full Name From First and Last Name If Not Available (merge to develop)

### DIFF
--- a/components/signup/signup_lti/signup_lti.jsx
+++ b/components/signup/signup_lti/signup_lti.jsx
@@ -140,7 +140,11 @@ export default class SignupLTI extends React.Component {
             [LTIConstants.EMAIL_FIELD]: email,
             [LTIConstants.FULLNAME_FIELD]: fullName,
             [LTIConstants.USERNAME_FIELD]: username,
+            [LTIConstants.FIRST_NAME_FIELD]: firstName = '',
+            [LTIConstants.LAST_NAME_FIELD]: lastName = '',
         } = formData;
+
+        const name = (fullName || `${firstName.trim()} ${lastName.trim()}`).trim();
 
         let emailError = null;
         let emailDivStyle = 'form-group';
@@ -193,7 +197,7 @@ export default class SignupLTI extends React.Component {
                                 type='text'
                                 ref='fullname'
                                 className='form-control'
-                                defaultValue={fullName}
+                                value={name}
                                 disabled={true}
                             />
                         </div>
@@ -211,7 +215,7 @@ export default class SignupLTI extends React.Component {
                                 type='text'
                                 ref='username'
                                 className='form-control'
-                                defaultValue={username}
+                                value={username}
                                 disabled={true}
                             />
                             {usernameError}
@@ -230,7 +234,7 @@ export default class SignupLTI extends React.Component {
                                 type='email'
                                 ref='email'
                                 className='form-control'
-                                defaultValue={email}
+                                value={email}
                                 disabled={true}
                             />
                             {emailError}

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -2532,7 +2532,7 @@
   "signup_LTI.fullname": "Full Name",
   "signup_LTI.position": "Position",
   "signup_LTI.username": "Username",
-  "signup_LTI.invalid_request": "There was an error with your login request. Please try again or contact your system administrator. Error code LTI-27",
+  "signup_LTI.invalid_request": "LTI-27: LTI signup cookie could not be read from the cookie.",
   "signup.office365": "Office 365",
   "signup.saml.icon": "SAML Icon",
   "signup.title": "Create an account with:",

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -689,6 +689,8 @@ export const LTIConstants = {
     EMAIL_FIELD: 'lis_person_contact_email_primary',
     USERNAME_FIELD: 'lis_person_sourcedid',
     FULLNAME_FIELD: 'lis_person_name_full',
+    FIRST_NAME_FIELD: 'lis_person_name_given',
+    LAST_NAME_FIELD: 'lis_person_name_family',
     LAUNCH_DATA_COOKIE: 'MMLTILAUNCHDATA',
 };
 


### PR DESCRIPTION
#### Summary
Generated Full Name From First and Last Name If Not Available.

Only use first name and last name in server side to build user. This PR allows displaying full name from the first name and last name if full name was not passed from LMS so that the signup page displays the correct full name.

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed