### PR TITLE
replace most uses of underscore package

### DIFF
--- a/actions/views/dashboard.js
+++ b/actions/views/dashboard.js
@@ -1,10 +1,86 @@
 // Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" } }]
+ */
+
 import _ from 'underscore';
 
 import {DashboardActionTypes} from 'utils/constants.jsx';
 import {app, logger} from 'utils/riff';
+
+// TODO: consider moving these functions to a utility file such as
+// utils/riff.
+/**
+ * Returns an object whose properties are the values of the specified
+ * property of the members of the given array. The value of those
+ * properties is an array containing the members of the original
+ * array with the property with that value.
+ *
+ * Replaces one use of the underscore package's groupBy function.
+ */
+function groupByPropertyValue(a, p) {
+    return a.reduce((grouped, cur) => {
+        if (!(p in grouped)) {
+            grouped[cur[p]] = [];
+        }
+        grouped[cur[p]].push(cur);
+        return grouped;
+    }, {});
+}
+
+/**
+ * Returns a new object with the same properties as the given
+ * object, but whose values are those returned by the given
+ * function. The given function takes 2 args, the property
+ * value and the property key.
+ *
+ * Replaces the underscore mapObject function.
+ */
+function mapObject(o, f) {
+    const newO = {...o};
+    for (const [k, v] of Object.entries(newO)) {
+        newO[k] = f(v, k);
+    }
+    return newO;
+}
+
+/**
+ * Returns the time difference in seconds between the given
+ * start and end times.
+ */
+function getDurationInSeconds(startTime, endTime) {
+    const start = new Date(startTime);
+    const end = new Date(endTime);
+    const durationSecs = (end.getTime() - start.getTime()) / 1000;
+    return durationSecs;
+}
+
+/**
+ * Get a comparison functor for the property of an object whose
+ * values can be compared using the standard comparison operators.
+ *
+ * @returns {function(a, b)}
+ *      A function that takes 2 object, a and b, and returns
+ *      -1 if a[prop] < b[prop], 1 if a[prop] > b[prop], 0 if a[prop] = b[prop]
+ */
+function cmpObjectProp(prop) {
+    return (a, b) => {
+        return a[prop] < b[prop] ? -1 : a[prop] > b[prop] ? 1 : 0; // eslint-disable-line no-nested-ternary
+    };
+}
+
+/**
+ * Return a function that reverses the sense of the given comparison
+ * functor. So when used with the Array.sort it will turn an ascending
+ * sort into a descending sort (and vice-versa).
+ */
+function reverseCmp(cmp) {
+    return (a, b) => cmp(b, a);
+}
 
 export const loadMoreMeetings = () => {
     return {
@@ -36,62 +112,62 @@ export const loadRecentMeetings = (uid) => (dispatch) => {
     // we re-set this after the following block of code.
     dispatch(updateMeetingList([]));
 
-    return app.
-        service('participants').
-        find({query: {_id: uid}}).
-        then((res) => {
+    return app
+        .service('participants')
+        .find({query: {_id: uid}})
+        .then((res) => {
             if (res.data.length === 0) {
                 // no found participants. Throw an error to break out early.
                 throw new Error('no participant');
             }
             logger.debug('>>fetched participant:', res);
             return res.data[0];
-        }).
-        then((participant) => {
+        })
+        .then((participant) => {
             return participant.meetings;
-        }).
-        then((meetingIds) => {
+        })
+        .then((meetingIds) => {
             return app.service('meetings').find({query: {_id: meetingIds}});
-        }).
-        then((allMeetingObjsForParticipant) => {
+        })
+        .then((allMeetingObjsForParticipant) => {
             logger.debug('raw meeting objects received:', allMeetingObjsForParticipant);
             const usefulMeetings = allMeetingObjsForParticipant.filter((m) => {
+                //  any meeting "in progress" is useful
                 if (!m.endTime) {
                     return true;
                 }
-                const durationSecs =
-                    (new Date(m.endTime).getTime() -
-                        new Date(m.startTime).getTime()) /
-                    1000;
+
+                // meetings longer than 2 minutes are useful
+                const durationSecs = getDurationInSeconds(m.startTime, m.endTime);
                 return durationSecs > 2 * 60;
             });
 
             if (usefulMeetings.length === 0) {
-                throw new Error('no meetings after filter');
+                throw new Error('no useful meetings after filter');
             }
 
             // fetch data for first meeting
             return usefulMeetings;
 
             // dispatch(updateMeetingList(usefulMeetings));
-        }).
-        then((meetingObjects) => {
-            const pEvents = _.map(meetingObjects, (m) => {
-                return app.
-                    service('participantEvents').
-                    find({query: {meeting: m._id, $limit: 500}});
+        })
+        .then((meetingObjects) => {
+            const pEvents = meetingObjects.map((m) => {
+                return app
+                    .service('participantEvents')
+                    .find({query: {meeting: m._id, $limit: 500}}); // eslint-disable-line no-underscore-dangle
             });
             return Promise.all(pEvents).then((vals) => {
                 logger.debug('pevents in promise', vals);
                 return {meetings: meetingObjects, pEvents: vals};
             });
-        }).
-        then(({meetings, pEvents}) => {
+        })
+        .then(({meetings, pEvents}) => {
             // only return meetings that have over 1 participant.
-            const numParticipants = _.map(pEvents, (pe) => {
+            const numParticipants = pEvents.map((pe) => {
                 return _.uniq(
                     _.flatten(
-                        _.map(pe.data, (p) => {
+                        pe.data.map((p) => {
                             return p.participants;
                         })
                     )
@@ -103,30 +179,28 @@ export const loadRecentMeetings = (uid) => (dispatch) => {
             // right thing to do here is to try and create a service on the server that will reliably give
             // us # of attendees
             logger.debug('num participants:', numParticipants, meetings);
-            meetings = _.filter(meetings, (m, idx) => {
+            const meetingsWithOthers = meetings.filter((m, idx) => {
                 return numParticipants[idx] >= 2;
             });
-            logger.debug('kept meetings:', meetings);
-            if (meetings.length === 0) {
-                throw new Error('no meetings after nparticipants filter');
+            logger.debug('kept meetings:', meetingsWithOthers);
+            if (meetingsWithOthers.length === 0) {
+                throw new Error('no meetings after participants filter');
             }
-            meetings.sort(
-                (a, b) => /*descending*/ -cmpMeetingsByStartTime(a, b)
-            );
+            meetingsWithOthers.sort(reverseCmp(cmpObjectProp('startTime'))); // sort by descending time
 
             // limit to 10 to begin with
             //meetings = _.first(meetings, 2);
 
-            dispatch(updateMeetingList(meetings));
-            if (meetings.length > 0) {
-                const newSelectedMeeting = meetings[0];
-                logger.debug('meeting list is now:', meetings);
-                logger.debug('selected meeting is:', meetings[0]._id);
+            dispatch(updateMeetingList(meetingsWithOthers));
+            if (meetingsWithOthers.length > 0) {
+                const newSelectedMeeting = meetingsWithOthers[0];
+                logger.debug('meeting list is now:', meetingsWithOthers);
+                logger.debug('selected meeting is:', meetingsWithOthers[0]._id); // eslint-disable-line no-underscore-dangle
                 dispatch(selectMeeting(newSelectedMeeting));
-                dispatch(loadMeetingData(uid, newSelectedMeeting._id));
+                dispatch(loadMeetingData(uid, newSelectedMeeting._id)); // eslint-disable-line no-underscore-dangle
             }
-        }).
-        catch((err) => {
+        })
+        .catch((err) => {
             if (err.message === 'no participant') {
                 dispatch({
                     type: DashboardActionTypes.DASHBOARD_LOADING_ERROR,
@@ -162,44 +236,21 @@ const processUtterances = (utterances, meetingId) => {
 //    logger.debug('processing utterances:', utterances);
 
     // {'participant': [utteranceObject, ...]}
-    const participantUtterances = _.groupBy(utterances, 'participant');
+    const participantUtterances = groupByPropertyValue(utterances, 'participant');
 
     // {'participant': number of utterances}
-    const numUtterances = _.mapObject(participantUtterances, (val) => {
+    const numUtterances = mapObject(participantUtterances, (val) => {
         return val.length;
     });
-    var lengthUtterances = _.mapObject(participantUtterances, (val, key) => {
-        var lengthsUtterances = val.map((utteranceObject) => {
-            return (
-                (new Date(utteranceObject.endTime).getTime() -
-                    new Date(utteranceObject.startTime).getTime()) /
-                1000
-            );
-        });
-        return lengthsUtterances.reduce(
-            (previous, current) => current + previous,
-            0
-        );
+    const lengthUtterances = mapObject(participantUtterances, (val) => {
+        return val.reduce((uSecs, u) => uSecs + getDurationInSeconds(u.startTime, u.endTime), 0);
     });
 
     // {'participant': mean length of utterances in seconds}
-    var meanLengthUtterances = _.mapObject(
-        participantUtterances,
-        (val, key) => {
-            var lengthsUtterances = val.map((utteranceObject) => {
-                return (
-                    (new Date(utteranceObject.endTime).getTime() -
-                        new Date(utteranceObject.startTime).getTime()) /
-                    1000
-                );
-            });
-            var sum = lengthsUtterances.reduce(
-                (previous, current) => current + previous,
-                0
-            );
-            return sum / lengthsUtterances.length;
-        }
-    );
+    const meanLengthUtterances = participantUtterances.keys().reduce((meanU, k) => {
+        meanU[k] = lengthUtterances[k] / numUtterances[k];
+        return meanU;
+    }, {});
     const participants = Object.keys(participantUtterances);
 
     const visualizationData = participants.map((participantId) => {
@@ -224,14 +275,14 @@ const processUtterances = (utterances, meetingId) => {
 
     logger.debug('viz data:', visualizationData);
 
-    _.map(visualizationData, (v) => {
+    visualizationData.map((v) => {
         return Object.assign(v, {
             displayName: 'displayName',
             meetingId,
         });
     });
 
-    // const promises = _.map(visualizationData, (v) => {
+    // const promises = visualizationData.map((v) => {
     //     const docId = v.participantId + '_' + meetingId;
     //     const docRef = db.collection('meetings').doc(docId);
     //     return docRef.get().then((doc) => {
@@ -247,33 +298,24 @@ const processUtterances = (utterances, meetingId) => {
     return visualizationData;
 };
 
-/***************************************************************************
- * cmpMeetingsByStartTime
- *
- * Comparison functor for meetings based on their start times.
- *
- * @returns {number} -1 if a < b, 1 if a > b, 0 if a = b
- */
-function cmpMeetingsByStartTime(a, b) {
-    return a.startTime < b.startTime ? -1 : a.startTime > b.startTime ? 1 : 0; // eslint-disable-line no-nested-ternary
-}
-
-export const processInfluence = (uid, utterances, meetingId) => {
-    const participantUtterances = _.groupBy(utterances, 'participant');
+export const processInfluence = (uid, utterances, meetingId) => { // eslint-disable-line no-unused-vars
+    const participantUtterances = groupByPropertyValue(utterances, 'participant');
     const participants = Object.keys(participantUtterances);
-    const sortedUtterances = _.sortBy(utterances, (u) => { return u.startTime; });
+    const sortedUtterances = utterances.slice().sort(cmpObjectProp('startTime'));
 
-    let recentUttCounts = _.map(sortedUtterances, (ut, idx) => {
+    let recentUttCounts = sortedUtterances.map((ut, idx) => {
         // get list of utterances within 2 seconds that are not by the speaker.
-        const recentUtterances = _.filter(sortedUtterances.slice(0, idx), (recentUt) => {
-            const timeDiff = ((new Date(ut.startTime).getTime() - new Date(recentUt.endTime).getTime())/1000);
+        const recentUtterances = sortedUtterances.slice(0, idx).filter((recentUt) => {
+            const timeDiff = getDurationInSeconds(ut.startTime, recentUt.endTime);
             const recent = timeDiff < 3 && timeDiff > 0;
             const sameParticipant = ut.participant === recentUt.participant;
             return recent && !sameParticipant;
         });
         if (recentUtterances.length > 0) {
-            return {participant: ut.participant,
-                    counts: _.countBy(recentUtterances, 'participant')};
+            return {
+                participant: ut.participant,
+                counts: _.countBy(recentUtterances, 'participant'),
+            };
         }
         return false;
     });
@@ -283,72 +325,68 @@ export const processInfluence = (uid, utterances, meetingId) => {
 
     // create object with the following format:
     // {participantId: {participantId: Count, participantId: Count, ...}}
-    const aggregatedCounts = _.reduce(recentUttCounts, (memo, val, idx, l) => {
-        if (!memo[val.participant]) {
-            memo[val.participant] = val.counts;
-        } else {
-            // update count object that's stored in memo, adding new
-            // keys as we need to.
-            // obj here should be an object of {participantId: nUtterances}
-            const obj = memo[val.participant];
-            _.each(_.pairs(val.counts), (pair) => {
-                if (!obj[pair[0]]) {
-                    obj[pair[0]] = pair[1];
-                } else {
-                    obj[pair[0]] += pair[1];
-                }
-            });
-            memo[val.participant] = obj;
+    const aggregatedCounts = recentUttCounts.reduce((memo, ut) => {
+        if (!(ut.participant in memo)) {
+            memo[ut.participant] = {};
         }
+
+        // update count object that's stored in memo, adding new
+        // keys as we need to.
+        // obj here should be an object of {participantId: nUtterances}
+        const obj = memo[ut.participant];
+        for (const [k, v] of Object.entries(ut.counts)) {
+            if (k in obj) {
+                obj[k] += v;
+            } else {
+                obj[k] = v;
+            }
+        }
+
         return memo;
     }, {});
 
     // limit to only the current user
     //aggregatedCounts = aggregatedCounts[uid];
 
-    let finalEdges = [];
-    const edges = _.each(_.pairs(aggregatedCounts), (obj, idx) => {
-        const participant = obj[0];
-        _.each(_.pairs(obj[1]), (o) => {
-            const toAppend = {source: participant, target: o[0], size: o[1]};
-            finalEdges.push(toAppend);
-        });
-    });
-
-    finalEdges = _.map(finalEdges, (e, idx) => { return { ...e,
-                                                          id: 'e' + idx,
-                                                          size: e.size};});
+    const finalEdges = [];
+    for (const [mainParticipant, counts] of Object.entries(aggregatedCounts)) {
+        for (const [participant2, cnt] of Object.entries(counts)) {
+            const id = `e${finalEdges.length}`;
+            const edge = {id, source: mainParticipant, target: participant2, size: cnt};
+            finalEdges.push(edge);
+        }
+    }
 
     // filter any edges under 0.2 weight
     //finalEdges = _.filter(finalEdges, (e) => { return !(e.size < 0.1*sizeMultiplier); });
-    let nodes = _.map(participants, (p, idx) => { return {id: p}; });
-    nodes = _.sortBy(nodes, 'id');
+
+    const nodes = participants.map((p) => ({id: p}));
+    nodes.sort(cmpObjectProp('id'));
 
     const barLabels = {};
-    const promises = _.map(nodes, (n) => {
+    const promises = nodes.map((n) => {
         return app.service('participants').get(n.id)
             .then((res) => {
                 barLabels[n.id] = res.name;
-                return {...n,
-                        label: res.name};
+                return {
+                    ...n,
+                    label: res.name,
+                };
             });
     });
 
-    return Promise.all(promises).then((values) => {
-        finalEdges = _.map(finalEdges, (e, idx) => {
-            return {
-                ...e,
-                targetName: barLabels[e.target],
-                sourceName: barLabels[e.source],
-            };
+    return Promise.all(promises).then(() => {
+        finalEdges.forEach((e) => {
+            e.targetName = barLabels[e.target];
+            e.sourceName = barLabels[e.source];
         });
         return finalEdges;
     });
 };
 
-export const processTimeline = (uid, utterances, meetingId) => {
-    const participantUtterances = _.groupBy(utterances, 'participant');
-    let utts = _.map(utterances, (u) => {
+export const processTimeline = (uid, utterances, meetingId) => { // eslint-disable-line no-unused-vars
+    const participantUtterances = groupByPropertyValue(utterances, 'participant');
+    const utts = utterances.map((u) => {
         return {
             ...u,
             startDate: new Date(u.startTime),
@@ -357,19 +395,17 @@ export const processTimeline = (uid, utterances, meetingId) => {
         };
     });
 
-    utts = _.sortBy(utts, (u) => {
-        return u.startDate;
-    });
+    utts.sort(cmpObjectProp('startTime'));
 
-    const participants = Object.keys(participantUtterances);
-    let otherParticipants = _.filter(participants, (p) => { return p !== uid; });
+    const participantIds = Object.keys(participantUtterances);
+    const otherParticipantIds = participantIds.filter((p) => (p !== uid));
     logger.debug('local uid:', uid);
-    logger.debug('other participants:', otherParticipants);
-    const promises = _.map(otherParticipants, (p) => {
-        return app.
-            service('participants').
-            get(p).
-            then((res) => {
+    logger.debug('other participants:', otherParticipantIds);
+    const promises = otherParticipantIds.map((p) => {
+        return app
+            .service('participants')
+            .get(p)
+            .then((res) => {
                 return {name: res.name, id: p};
             });
     });
@@ -383,13 +419,12 @@ export const processTimeline = (uid, utterances, meetingId) => {
 
     return Promise.all(promises).then((participants) => {
         // add local participant
-        participants = _.sortBy(participants, 'id');
-        participants.unshift({name: 'You',
-                              id: uid});
-        logger.debug('sending sorted participants:', participants);
+        const sortedParticipants = participants.slice(0).sort(cmpObjectProp('id'));
+        sortedParticipants.unshift({name: 'You', id: uid});
+        logger.debug('sending sorted participants:', sortedParticipants);
         return {
             utts,
-            participants,
+            sortedParticipants,
             startTime,
             endTime,
         };
@@ -404,18 +439,18 @@ export const loadMeetingData = (uid, meetingId) => (dispatch) => {
         meetingId,
     });
     logger.debug('finding utterances for meeting', meetingId);
-    return app.
-        service('utterances').
-        find({query: {meeting: meetingId, $limit: 10000, stitch: true}}).
-        then((utterances) => {
+    return app
+        .service('utterances')
+        .find({query: {meeting: meetingId, $limit: 10000, stitch: true}})
+        .then((utterances) => {
             logger.debug('>>>', meetingId, 'utterances', utterances);
             return {
                 processedUtterances: processUtterances(utterances, meetingId),
                 processedInfluence: processInfluence(uid, utterances, meetingId),
                 processedTimeline: processTimeline(uid, utterances, meetingId),
             };
-        }).
-        then(({processedUtterances, processedInfluence, processedTimeline}) => {
+        })
+        .then(({processedUtterances, processedInfluence, processedTimeline}) => {
             logger.debug(
                 'utterances:',
                 processedUtterances,
@@ -426,16 +461,18 @@ export const loadMeetingData = (uid, meetingId) => (dispatch) => {
             );
 
             processedInfluence.then((influenceObj) => {
-                dispatch({type: DashboardActionTypes.DASHBOARD_FETCH_MEETING_INFLUENCE,
-                          meetingId,
-                          influenceData: influenceObj});
+                dispatch({
+                    type: DashboardActionTypes.DASHBOARD_FETCH_MEETING_INFLUENCE,
+                    meetingId,
+                    influenceData: influenceObj,
+                });
             });
 
-            const promises = _.map(processedUtterances, (u) => {
-                return app.
-                    service('participants').
-                    get(u.participantId).
-                    then((res) => {
+            const promises = processedUtterances.map((u) => {
+                return app
+                    .service('participants')
+                    .get(u.participantId)
+                    .then((res) => {
                         return {...u, name: res.name};
                     });
             });
@@ -478,8 +515,8 @@ export const loadMeetingData = (uid, meetingId) => (dispatch) => {
                     timelineData: processedTimeline,
                 });
             });
-        }).
-        catch((err) => {
+        })
+        .catch((err) => {
             // re-call load meeting here?
             logger.error("couldn't retrieve meeting data", err);
         });


### PR DESCRIPTION
#### Summary
The `underscore` package is pretty large, and most of the uses are now available in the
ecmascript language (map, filter, sort...) so it would be nice to replace all uses
of the package so we can remove the dependency.

I left some of the underscore calls behind for now (uniq, compact, flatten, etc.), but I anticipate getting to them at some point.

I also rewrote some of the algorithms slightly while I was at it, all results are
still supposed to be the same, if they're not I've got a bug.

Well except for the comparison of startDate which is a Date object, and I'm sure it
wasn't supposed to compare object but the date it represents (so I changed it to compare
startTime).

I also cleaned up more  style errors.

@jordanreedie @iamtomhanks These changes need a thorough review before they are merged.
Thanks

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
