### PR TITLE
Fix firebase warning, more style errors

### DIFF
--- a/actions/views/riff.js
+++ b/actions/views/riff.js
@@ -1,8 +1,10 @@
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {RiffServerActionTypes} from '../../utils/constants';
 
-import {app, socket} from '../../utils/riff';
+/* eslint header/header: "off" */
+
+import {RiffServerActionTypes} from 'utils/constants';
+import {app, socket, logger} from 'utils/riff';
 
 export const riffAuthSuccess = (token) => {
     return {
@@ -19,7 +21,7 @@ export const riffAuthFail = (err) => {
 };
 
 export const updateTurnData = (transitions, turns) => {
-    console.log('updating turn data:', transitions, turns);
+    logger.debug('updating turn data:', transitions, turns);
     return {
         type: RiffServerActionTypes.RIFF_TURN_UPDATE,
         transitions,
@@ -28,7 +30,7 @@ export const updateTurnData = (transitions, turns) => {
 };
 
 export const updateMeetingParticipants = (participants) => {
-    console.log('updating riff meeting participants', participants);
+    logger.debug('updating riff meeting participants', participants);
     return {
         type: RiffServerActionTypes.RIFF_PARTICIPANTS_CHANGED,
         participants,
@@ -48,18 +50,13 @@ export const participantLeaveRoom = (meetingId, participantId) => {
         patch(meetingId, {
             remove_participants: [participantId],
         }).
-        then((res) => {
-            console.log(
-                'removed participant:',
-                participantId,
-                'from meeting ',
-                meetingId
-            );
+        then(() => {
+            logger.debug(`removed participant: ${participantId} from meeting ${meetingId}`);
             return true;
         }).
         catch((err) => {
+            logger.error('shit, caught an error:', err);
             return false;
-            console.log('shit, caught an error:', err);
         });
 };
 
@@ -70,15 +67,15 @@ export const attemptRiffAuthenticate = () => (dispatch) => {
         password: 'default-user-password',
     }).
         then((result) => {
-            console.log('auth result!: ', result);
+            logger.debug('riff data server auth result!: ', result);
             dispatch(riffAuthSuccess(result.accessToken));
 
             //return this.recordMeetingJoin();
         }).
         catch((err) => {
-            console.log('auth ERROR:', err);
+            logger.warn('riff data server auth ERROR:', err);
             dispatch(riffAuthFail(err));
-            console.log('trying to authenticate again...');
+            logger.info('trying to authenticate again...');
             dispatch(attemptRiffAuthenticate());
         });
 };
@@ -92,7 +89,6 @@ export const riffAddUserToMeeting = (
     currentUsers,
     token
 ) => {
-    
     const parts = currentUsers.map((user) => {
         return {participant: user.id};
     });

--- a/utils/firebase/index.js
+++ b/utils/firebase/index.js
@@ -1,5 +1,8 @@
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
+
+/* eslint header/header: "off" */
+
 import firebase from 'firebase/app';
 import 'firebase/auth';
 import 'firebase/firestore';
@@ -22,8 +25,17 @@ const app = firebase.initializeApp(config);
 //   [2018-10-09T19:48:08.741Z]  @firebase/firestore: Firestore (5.5.0):
 //   The behavior for Date objects stored in Firestore is going to change
 //   AND YOUR APP MAY BREAK.
+//
+// The new firebase warning:
+//   [2019-02-11T19:51:57.937Z]  @firebase/firestore: Firestore (5.8.1):
+//   The timestampsInSnapshots setting now defaults to true and you no
+//   longer need to explicitly set it. In a future release, the setting
+//   will be removed entirely and so it is recommended that you remove it
+//   from your firestore.settings() call now.
+// I'm leaving the empty settings object to make it easier if we need to
+// add settings back again.
 const firestore = app.firestore();
-const settings = {timestampsInSnapshots: true};
+const settings = {};
 firestore.settings(settings);
 
 export default app;

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -1,3 +1,8 @@
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint header/header: "off", dot-location: ["error", "property"] */
+
 import feathers from '@feathersjs/feathers';
 import socketio from '@feathersjs/socketio-client';
 import auth from '@feathersjs/authentication-client';
@@ -5,35 +10,48 @@ import io from 'socket.io-client';
 
 // access to api
 
-let dataserverPath = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.RIFF_SERVER_PATH : process.env.RIFF_SERVER_PATH;
-console.log("path envs:", process.env.CLIENT_ENV, process.env.RIFF_SERVER_PATH);
-dataserverPath = dataserverPath ? dataserverPath : '';
-dataserverPath += '/socket.io';
-
-let dataserverUrl = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.RIFF_SERVER_URL : process.env.RIFF_SERVER_URL;
-console.log("data server path:", dataserverPath)
-console.log("data server URL:", dataserverUrl)
-
-export const socket = io(dataserverUrl, {
-    'timeout': 20000,
-    'path': dataserverPath,
-    'transports': [
-        'websocket',
-        'flashsocket',
-        'htmlfile',
-        'xhr-polling',
-        'jsonp-polling'
-    ]
-});
-
-
-export var app = feathers()
-    .configure(socketio(socket))
-    .configure(auth({jwt: {}, local: {}}));
-
+/**
+ * logger is a poor man's cheap logger for client code.
+ *
+ * It mostly just redirects to using the window console
+ * log, EXCEPT it allows debug logging to be enabled or
+ * disabled.
+ *
+ * By using this logger instead of console.log directly
+ * we can more easily replace all logging with a fancier
+ * logger package w/ more functionality at some later time
+ * if desired.
+ */
+/* eslint-disable no-console, no-empty-function */
 export const logger = {
     debug: window.client_config && window.client_config.react_app_debug ? console.log.bind(window.console) : () => {},
     info: console.log.bind(window.console),
     warn: console.warn.bind(window.console),
     error: console.error.bind(window.console),
-}
+};
+/* eslint-enable no-console, no-empty-function */
+
+let dataserverPath = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.RIFF_SERVER_PATH : process.env.RIFF_SERVER_PATH;
+logger.debug('path envs:', process.env.CLIENT_ENV, process.env.RIFF_SERVER_PATH);
+dataserverPath = dataserverPath || '';
+dataserverPath += '/socket.io';
+
+const dataserverUrl = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.RIFF_SERVER_URL : process.env.RIFF_SERVER_URL;
+logger.debug('data server path:', dataserverPath);
+logger.debug('data server URL:', dataserverUrl);
+
+export const socket = io(dataserverUrl, {
+    timeout: 20000,
+    path: dataserverPath,
+    transports: [
+        'websocket',
+        'flashsocket',
+        'htmlfile',
+        'xhr-polling',
+        'jsonp-polling',
+    ],
+});
+
+export var app = feathers()
+    .configure(socketio(socket))
+    .configure(auth({jwt: {}, local: {}}));


### PR DESCRIPTION
#### Summary
Fix the firebase warning about a configuration setting that is now showing up in the console.

```
[2019-02-11T19:51:57.937Z]  @firebase/firestore: Firestore (5.8.1):
The timestampsInSnapshots setting now defaults to true and you no
longer need to explicitly set it. In a future release, the setting
will be removed entirely and so it is recommended that you remove it
from your firestore.settings() call now.
```
#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
