### PR TITLE
Update localmedia version in package-lock to match riff-rtc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10140,7 +10140,7 @@
       }
     },
     "localmedia": {
-      "version": "github:jordanreedie/localmedia#c874917f5dbc0de7c17c8c8ef9ceb1ddb9176465",
+      "version": "github:jordanreedie/localmedia#703718222720c5ccaa56bbfe3dc12875c9ff02ae",
       "from": "github:jordanreedie/localmedia#feature/update-get-screen",
       "requires": {
         "hark": "^1.0.0",
@@ -15219,7 +15219,7 @@
       "requires": {
         "attachmediastream": "github:jordanreedie/attachMediaStream#889613872dae1a46eacade0f07e5e0c8b637e848",
         "filetransfer": "^2.0.4",
-        "localmedia": "github:jordanreedie/localmedia#c874917f5dbc0de7c17c8c8ef9ceb1ddb9176465",
+        "localmedia": "github:jordanreedie/localmedia#703718222720c5ccaa56bbfe3dc12875c9ff02ae",
         "mockconsole": "0.0.1",
         "rtcpeerconnection": "^8.0.0",
         "socket.io-client": "^1.7.4",


### PR DESCRIPTION
#### Summary
Updating this fixed screensharing for me in Linux/Ubuntu/Chrome.

#### Ticket Link
https://trello.com/c/QALL1fUK/229-bug-echo-is-screen-sharing
https://trello.com/c/GBx6UsgX/213-screen-sharing-add-feature-to-riff-edu