### PR TITLE
Bug: Link color not stylized in Edu lobby.

### DIFF
--- a/sass/components/_bulma.scss
+++ b/sass/components/_bulma.scss
@@ -50,8 +50,14 @@ $blue: rgb(19,129,161);
 $primary: $purple;
 $link: $purple;
 
-a:hover {
-    color: $purpleHover;
+html {
+  a {
+    color: $purple;
+    &:hover {
+        color: #363636;
+        text-decoration: none;
+    }
+  }
 }
 
 .sigma-scene {


### PR DESCRIPTION
#### Summary
Link color inside the sidebar was not the Riff purple color. It has been fixed.

All links will now be the Riff purple.
#### Ticket Link
https://trello.com/c/v99etNNa/227-bug-link-color-not-stylized-in-edu-lobby

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes
