### PR TITLE
logger.setLogLevel; riffConfig w/ pseudo config values for dataserver and signalmaster

### DIFF
--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -10,6 +10,15 @@ import io from 'socket.io-client';
 
 // access to api
 
+/* eslint-disable no-console, no-empty-function */
+// Noop function to use for disabled log levels
+const noopFn = () => {};
+
+const infoLog = console.log.bind(window.console);
+const warnLog = console.warn.bind(window.console);
+const errorLog = console.error.bind(window.console);
+/* eslint-enable no-console, no-empty-function */
+
 /**
  * logger is a poor man's cheap logger for client code.
  *
@@ -22,27 +31,68 @@ import io from 'socket.io-client';
  * logger package w/ more functionality at some later time
  * if desired.
  */
-/* eslint-disable no-console, no-empty-function */
 export const logger = {
-    debug: window.client_config && window.client_config.react_app_debug ? console.log.bind(window.console) : () => {},
-    info: console.log.bind(window.console),
-    warn: console.warn.bind(window.console),
-    error: console.error.bind(window.console),
+    debug: infoLog,
+    info: infoLog,
+    warn: warnLog,
+    error: errorLog,
+
+    setLogLevel(level) {
+        this.debug = noopFn;
+        this.info = noopFn;
+        this.warn = noopFn;
+        this.error = noopFn;
+
+        /* eslint-disable no-fallthrough */
+        switch (level) {
+        case 'debug':
+            this.debug = infoLog;
+        case 'info':
+            this.info = infoLog;
+        case 'warn':
+            this.warn = warnLog;
+        case 'error':
+            this.error = errorLog;
+        }
+        /* eslint-enable no-fallthrough */
+    },
 };
-/* eslint-enable no-console, no-empty-function */
 
-let dataserverPath = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.RIFF_SERVER_PATH : process.env.RIFF_SERVER_PATH;
+// Default dataserver and signalmaster url and path values which work w/ the reverse proxy
+export const config = {
+    logLevel: 'debug',
+    dataserverUrl: '/',
+    dataserverPath: '/api/videodata',
+    signalmasterUrl: '/',
+    signalmasterPath: '/api/signalmaster',
+};
+
+// TODO: get the client log level from some real configuration sent from the server
+const configLogLevel = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.RIFF_LOGLEVEL : process.env.RIFF_LOGLEVEL;
+config.logLevel = configLogLevel || 'debug';
+logger.setLogLevel(config.logLevel);
+
+// TODO: get the data server url and path from some real configuration sent from the server
 logger.debug('path envs:', process.env.CLIENT_ENV, process.env.RIFF_SERVER_PATH);
-dataserverPath = dataserverPath || '';
-dataserverPath += '/socket.io';
+const configDataserverUrl = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.RIFF_SERVER_URL : process.env.RIFF_SERVER_URL;
+const configDataserverPath = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.RIFF_SERVER_PATH : process.env.RIFF_SERVER_PATH;
 
-const dataserverUrl = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.RIFF_SERVER_URL : process.env.RIFF_SERVER_URL;
-logger.debug('data server path:', dataserverPath);
-logger.debug('data server URL:', dataserverUrl);
+const configSignalmasterUrl = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.SIGNALMASTER_URL : process.env.SIGNALMASTER_URL;
+const configSignalmasterPath = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.SIGNALMASTER_PATH : process.env.SIGNALMASTER_PATH;
 
-export const socket = io(dataserverUrl, {
+// override the defaults w/ the config values
+/* eslint-disable no-negated-condition, no-undefined */
+config.dataserverUrl = configDataserverUrl !== undefined ? configDataserverUrl : config.dataserverUrl;
+config.dataserverPath = configDataserverPath !== undefined ? configDataserverPath : config.dataserverPath;
+config.signalmasterUrl = configSignalmasterUrl !== undefined ? configSignalmasterUrl : config.signalmasterUrl;
+config.signalmasterPath = configSignalmasterPath !== undefined ? configSignalmasterPath : config.signalmasterPath;
+/* eslint-enable no-negated-condition, no-undefined */
+
+logger.debug('data server socket:', {url: config.dataserverUrl, path: config.dataserverPath + '/socket.io'});
+
+export const socket = io(config.dataserverUrl, {
     timeout: 20000,
-    path: dataserverPath,
+    path: config.dataserverPath + '/socket.io',
     transports: [
         'websocket',
         'flashsocket',

--- a/utils/webrtc/webrtc.js
+++ b/utils/webrtc/webrtc.js
@@ -5,9 +5,9 @@ import SimpleWebRtc from 'simplewebrtc';
 import Sibilant from 'sibilant-webaudio';
 import parse from 'url-parse';
 
-import * as WebRtcActions from '../../actions/webrtc_actions';
-import {updateRiffMeetingId} from '../../actions/views/riff';
-import {app, logger} from '../riff';
+import * as WebRtcActions from 'actions/webrtc_actions';
+import {updateRiffMeetingId} from 'actions/views/riff';
+import {app, logger, config as riffConfig} from 'utils/riff';
 
 export const createWebRtcLink = (teamName, channelName) => {
     const link = parse(window.location.href, true);
@@ -36,16 +36,13 @@ export function isScreenShareSourceAvailable() {
 
 export default function (localVideoNode, dispatch, getState) {
     //TODO: make dynamic
-    let signalmasterPath = process.env.CLIENT_ENV.SIGNALMASTER_PATH || '';
-    signalmasterPath += '/socket.io';
-    const signalmasterUrl = process.env.CLIENT_ENV.SIGNALMASTER_URL;
     const webRtcConfig = {
         localVideoEl: localVideoNode,
         remoteVideosEl: '',
         autoRequestMedia: true,
-        url: signalmasterUrl,
+        url: riffConfig.signalmasterUrl,
         socketio: {
-            path: signalmasterPath,
+            path: riffConfig.signalmasterPath + '/socket.io',
             forceNew: true,
         },
         media: {


### PR DESCRIPTION
#### Summary
Those config values now have defaults suitable for the expected docker service stack w/
the reverse proxy forwarding the websocket connections for the data server and signalmaster.

I left the process.env code there for the time being although that would hardcode the values
at build time. The right thing to do is to get the values from the mm-server config.

I moved getting the pseudo config values for the signalmaster url and path into the `utils/riff/index.js`
so that it is all together.

This should enable the "production" deployment to successfully connect to the data server and signalmaster, but it needs to be merged to verify that.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
