### PR TITLE
Fix dashboard lag

### DIFF
--- a/components/dashboard/components/MeetingViz.jsx
+++ b/components/dashboard/components/MeetingViz.jsx
@@ -124,17 +124,6 @@ class MeetingViz extends React.Component {
         timelineData: {},
     };
 
-    componentDidUpdate(prevProps, prevState) {
-        logger.debug(`--------debug--------`);
-        Object.entries(this.props).forEach(([key, val]) => {
-          if (prevProps[key] !== val) {
-            logger.debug(`DEBUG Prop '${key}' changed`)
-            logger.debug(`DEBUG Previous val: ${JSON.stringify(prevProps[key])}`)
-            logger.debug(`DEBUG New val: ${JSON.stringify(val)} `)
-
-          }
-        });
-    }
 
     shouldComponentUpdate(nextProps, nextState) {
       let shouldUpdate = false;
@@ -149,14 +138,13 @@ class MeetingViz extends React.Component {
          shouldUpdate = true;
       }
 
-      logger.debug(" DEBUG Should update?: ", shouldUpdate);
+      logger.debug("DEBUG Should update?: ", shouldUpdate);
       return shouldUpdate;
     }
 
     constructor(props) {
         super(props);
-        this.state = {
-        };
+        this.state = {};
 
         // only load if the data hasn't been loaded yet.
         // NEW: waypoint should take care of this for us.

--- a/components/dashboard/components/MeetingViz.jsx
+++ b/components/dashboard/components/MeetingViz.jsx
@@ -52,7 +52,7 @@ const mapStateToProps = (state, ownProps) => {
     const meetingId = ownProps.meeting._id;
     const idx = getMeetingIndex(dashboard.meetings, meetingId);
     logger.debug('meeting for this viz is:', riffState.meetings[idx]);
-    logger.debug('timeline for this viz is:', idx, dashboard.timelineData);
+    logger.debug('timeline for this viz is:', idx, dashboard.timelineData[idx]);
     return {
         processedUtterances: dashboard.processedUtterances[idx],
         influenceData: dashboard.influenceData[idx],
@@ -96,7 +96,7 @@ Header.propTypes = {
     selectedMeetingDuration: PropTypes.string,
 };
 
-class MeetingViz extends React.PureComponent {
+class MeetingViz extends React.Component {
     static propTypes = {
         user: PropTypes.object.isRequired,
         allMeetings: PropTypes.array.isRequired,
@@ -123,6 +123,35 @@ class MeetingViz extends React.PureComponent {
         influenceData: {},
         timelineData: {},
     };
+
+    componentDidUpdate(prevProps, prevState) {
+        logger.debug(`--------debug--------`);
+        Object.entries(this.props).forEach(([key, val]) => {
+          if (prevProps[key] !== val) {
+            logger.debug(`DEBUG Prop '${key}' changed`)
+            logger.debug(`DEBUG Previous val: ${JSON.stringify(prevProps[key])}`)
+            logger.debug(`DEBUG New val: ${JSON.stringify(val)} `)
+
+          }
+        });
+    }
+
+    shouldComponentUpdate(nextProps, nextState) {
+      let shouldUpdate = false;
+
+      if (nextProps.size.width > 0 && this.props.size.width !== nextProps.size.width) {
+         logger.debug('size changed');
+         shouldUpdate = true;
+      }
+
+      if (this.props.loaded !== nextProps.loaded) {
+         logger.debug('loaded changed')
+         shouldUpdate = true;
+      }
+
+      logger.debug(" DEBUG Should update?: ", shouldUpdate);
+      return shouldUpdate;
+    }
 
     constructor(props) {
         super(props);

--- a/components/dashboard/components/MeetingViz.jsx
+++ b/components/dashboard/components/MeetingViz.jsx
@@ -124,22 +124,21 @@ class MeetingViz extends React.Component {
         timelineData: {},
     };
 
-
     shouldComponentUpdate(nextProps, nextState) {
-      let shouldUpdate = false;
+        let shouldUpdate = false;
 
-      if (nextProps.size.width > 0 && this.props.size.width !== nextProps.size.width) {
-         logger.debug('size changed');
-         shouldUpdate = true;
-      }
+        if (nextProps.size.width > 0 && this.props.size.width !== nextProps.size.width) {
+            logger.debug('size changed');
+            shouldUpdate = true;
+        }
 
-      if (this.props.loaded !== nextProps.loaded) {
-         logger.debug('loaded changed')
-         shouldUpdate = true;
-      }
+        if (this.props.loaded !== nextProps.loaded) {
+            logger.debug('loaded changed')
+            shouldUpdate = true;
+        }
 
-      logger.debug("DEBUG Should update?: ", shouldUpdate);
-      return shouldUpdate;
+        logger.debug("DEBUG Should update?: ", shouldUpdate);
+        return shouldUpdate;
     }
 
     constructor(props) {

--- a/components/dashboard/components/MeetingViz.jsx
+++ b/components/dashboard/components/MeetingViz.jsx
@@ -1,6 +1,11 @@
 // Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint
+    header/header: "off",
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" } }]
+ */
+
 import React from 'react';
 import {connect} from 'react-redux';
 import sizeMe from 'react-sizeme';
@@ -49,7 +54,7 @@ const formatMeetingDuration = (meeting) => {
 const mapStateToProps = (state, ownProps) => {
     const {lti, dashboard, riff} = state.views;
     const riffState = {...lti, ...dashboard, ...riff};
-    const meetingId = ownProps.meeting._id;
+    const meetingId = ownProps.meeting._id; // eslint-disable-line no-underscore-dangle
     const idx = getMeetingIndex(dashboard.meetings, meetingId);
     logger.debug('meeting for this viz is:', riffState.meetings[idx]);
     logger.debug('timeline for this viz is:', idx, dashboard.timelineData[idx]);
@@ -74,9 +79,11 @@ const Header = (props) => {
     return (
         <div
             className=''
-            style={{paddingBottom: '2rem',
-                    paddingTop: '1rem',
-                    paddingLeft: '1rem'}}
+            style={{
+                paddingBottom: '2rem',
+                paddingTop: '1rem',
+                paddingLeft: '1rem',
+            }}
         >
             <h3>{`Meeting at: ${meetingDate}`} </h3>
             <SpaceBetweeen>
@@ -124,7 +131,7 @@ class MeetingViz extends React.Component {
         timelineData: {},
     };
 
-    shouldComponentUpdate(nextProps, nextState) {
+    shouldComponentUpdate(nextProps /*, nextState*/) {
         let shouldUpdate = false;
 
         if (nextProps.size.width > 0 && this.props.size.width !== nextProps.size.width) {
@@ -133,11 +140,11 @@ class MeetingViz extends React.Component {
         }
 
         if (this.props.loaded !== nextProps.loaded) {
-            logger.debug('loaded changed')
+            logger.debug('loaded changed');
             shouldUpdate = true;
         }
 
-        logger.debug("DEBUG Should update?: ", shouldUpdate);
+        logger.debug('DEBUG Should update?: ', shouldUpdate);
         return shouldUpdate;
     }
 
@@ -157,8 +164,8 @@ class MeetingViz extends React.Component {
         if (!this.props.loaded) {
             logger.debug('NOT loaded, waypoint loading this meeting...', event);
             this.props.loadMeetingData(this.props.user.id,
-                                       this.props.meeting._id);
-            this.props.maybeLoadNextMeeting(this.props.meeting._id, this.props.allMeetings);
+                                       this.props.meeting._id); // eslint-disable-line no-underscore-dangle
+            this.props.maybeLoadNextMeeting(this.props.meeting._id, this.props.allMeetings); // eslint-disable-line no-underscore-dangle
         }
     }
 

--- a/components/dashboard/index.js
+++ b/components/dashboard/index.js
@@ -16,7 +16,6 @@ import {
 } from '../../actions/views/dashboard';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import * as RiffServerActionCreators from '../../actions/views/riff';
-import {logger} from '../../utils/riff';
 
 import DashboardView from './DashboardView';
 
@@ -104,7 +103,6 @@ const mapMergeProps = (stateProps, dispatchProps, ownProps) => {
 };
 
 const componentDidUpdate = (props) => {
-    logger.debug("dashboard did update");
     if (props.riffAuthToken && props.shouldFetch) {
         props.loadRecentMeetings(props.user.id);
     }

--- a/components/dashboard/index.js
+++ b/components/dashboard/index.js
@@ -16,6 +16,7 @@ import {
 } from '../../actions/views/dashboard';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 import * as RiffServerActionCreators from '../../actions/views/riff';
+import {logger} from '../../utils/riff';
 
 import DashboardView from './DashboardView';
 
@@ -103,6 +104,7 @@ const mapMergeProps = (stateProps, dispatchProps, ownProps) => {
 };
 
 const componentDidUpdate = (props) => {
+    logger.debug("dashboard did update");
     if (props.riffAuthToken && props.shouldFetch) {
         props.loadRecentMeetings(props.user.id);
     }

--- a/reducers/views/dashboard.js
+++ b/reducers/views/dashboard.js
@@ -1,7 +1,15 @@
-// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import {DashboardActionTypes} from 'utils/constants.jsx';
+
+/* eslint
+    header/header: "off",
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" } }]
+ */
+
 import _ from 'underscore';
+
+import {DashboardActionTypes} from 'utils/constants.jsx';
+import {logger} from 'utils/riff';
 
 const initialState = {
     numMeetings: 0,
@@ -10,7 +18,7 @@ const initialState = {
     meetings: [],
     loadingError: {
         status: false,
-        message: ''
+        message: '',
     },
 
     // 'loaded' at idx if utterances, influence, and timeline are all loaded
@@ -18,45 +26,50 @@ const initialState = {
 
     // initial number of meetings to load
     numLoadedMeetings: 2,
-    // array holding processed data for each meeting. 
+
+    // array holding processed data for each meeting.
     processedUtterances: [],
     influenceData: [],
-    timelineData: []
+    timelineData: [],
 };
 
 const getMeetingIndex = (meetings, meetingId) => {
-    let meetingIds = _.pluck(meetings, '_id');
+    const meetingIds = _.pluck(meetings, '_id');
     return _.indexOf(meetingIds, meetingId);
-}
+};
 
 const updateDataArray = (arr, idx, newData) => {
-    return [...arr.slice(0, idx), newData, ...arr.slice(idx+1)];
-}
+    return [...arr.slice(0, idx), newData, ...arr.slice(idx + 1)];
+};
 
 const updateArr = (state, arr, meetingId, newData) => {
-    let idx = getMeetingIndex(state, meetingId);
-    console.log("index of meeting", meetingId, "is:", idx, state.meetings);
+    const idx = getMeetingIndex(state, meetingId);
+    logger.debug(`index of meeting ${meetingId} is: ${idx}`, state.meetings);
     return updateDataArray(arr, idx, newData);
-}
+};
 
 const updateLoadingStatus = (state) => {
-    let unzipped = _.unzip([state.processedUtterances,
-                            state.influenceData,
-                            state.timelineData]);
+    const unzipped = _.unzip([
+        state.processedUtterances,
+        state.influenceData,
+        state.timelineData,
+    ]);
 
-    console.log("meetingLoaded UNZIPPED:", unzipped)
+    logger.debug('meetingLoaded UNZIPPED:', unzipped);
 
-    let meetingLoaded = _.map(unzipped, (triple) => {
-        let bools = _.map(triple, (t) => { return Boolean(t)});
-        console.log("meetingLoaded mapped to bools:", bools)
+    const meetingLoaded = _.map(unzipped, (triple) => {
+        const bools = _.map(triple, (t) => {return Boolean(t);});
+        logger.debug('meetingLoaded mapped to bools:', bools);
         return _.every(bools);
     });
 
-    console.log("meetingLoaded", meetingLoaded)
-    let isLoadedArray = _.map(meetingLoaded, (m) => { return m ? 'loaded' : 'loading'});
-    return {...state,
-            statsStatus: isLoadedArray};
-}
+    logger.debug('meetingLoaded', meetingLoaded);
+    const isLoadedArray = _.map(meetingLoaded, (m) => {return m ? 'loaded' : 'loading';});
+    return {
+        ...state,
+        statsStatus: isLoadedArray,
+    };
+};
 
 const dashboard = (state = initialState, action) => {
     switch (action.type) {
@@ -65,11 +78,11 @@ const dashboard = (state = initialState, action) => {
     case DashboardActionTypes.DASHBOARD_LOAD_MORE_MEETINGS:
         return {
             ...state,
-            numLoadedMeetings: state.numLoadedMeetings + 1
+            numLoadedMeetings: state.numLoadedMeetings + 1,
         };
-    case DashboardActionTypes.DASHBOARD_FETCH_MEETINGS:
-        let timeDiff = ((((new Date()).getTime() - new Date(state.lastFetched).getTime())/1000) > 5);
-        console.log("time should fetch?", timeDiff);
+    case DashboardActionTypes.DASHBOARD_FETCH_MEETINGS: {
+        const timeDiff = ((((new Date()).getTime() - new Date(state.lastFetched).getTime()) / 1000) > 5);
+        logger.debug('time should fetch?', timeDiff);
         return {
             ...state,
             meetings: action.meetings ? action.meetings : state.meetings,
@@ -77,23 +90,24 @@ const dashboard = (state = initialState, action) => {
                 action.meetings.length :
                 state.meetings.length,
             lastFetched: new Date(),
-            shouldFetch: timeDiff
+            shouldFetch: timeDiff,
         };
+    }
     case DashboardActionTypes.DASHBOARD_LOADING_ALL_MEETINGS:
         return {
             ...state,
-            statsStatus: _.map(state.meetings, (m) => {return 'loading';}),
-            processedUtterances: _.map(state.meetings, (m) => {return false;}),
-            influenceData: _.map(state.meetings, (m) => {return false;}),
-            timelineData: _.map(state.meetings, (m) => {return false;})
+            statsStatus: _.map(state.meetings, () => {return 'loading';}),
+            processedUtterances: _.map(state.meetings, () => {return false;}),
+            influenceData: _.map(state.meetings, () => {return false;}),
+            timelineData: _.map(state.meetings, () => {return false;}),
         };
     case DashboardActionTypes.DASHBOARD_LOADING_ERROR:
         return {
             ...state,
             error: {
                 ...action.message,
-                ...action.status
-            }
+                ...action.status,
+            },
         };
 
     case DashboardActionTypes.DASHBOARD_MEETING_LOAD_STATUS:
@@ -102,7 +116,7 @@ const dashboard = (state = initialState, action) => {
             statsStatus: updateArr(state.meetings,
                                    state.statsStatus,
                                    action.meetingId,
-                                   action.status)
+                                   action.status),
         };
     case DashboardActionTypes.DASHBOARD_FETCH_MEETING_UTTERANCES:
         return updateLoadingStatus({
@@ -110,7 +124,7 @@ const dashboard = (state = initialState, action) => {
             processedUtterances: updateArr(state.meetings,
                                            state.processedUtterances,
                                            action.meetingId,
-                                           action.processedUtterances)
+                                           action.processedUtterances),
         });
     case DashboardActionTypes.DASHBOARD_FETCH_MEETING_INFLUENCE:
         return updateLoadingStatus({
@@ -118,7 +132,7 @@ const dashboard = (state = initialState, action) => {
             influenceData: updateArr(state.meetings,
                                      state.influenceData,
                                      action.meetingId,
-                                     action.influenceData)
+                                     action.influenceData),
         });
     case DashboardActionTypes.DASHBOARD_FETCH_MEETING_TIMELINE:
         return updateLoadingStatus({
@@ -126,7 +140,7 @@ const dashboard = (state = initialState, action) => {
             timelineData: updateArr(state.meetings,
                                     state.timelineData,
                                     action.meetingId,
-                                    action.timelineData)
+                                    action.timelineData),
         });
     default:
         return state;

--- a/reducers/views/dashboard.js
+++ b/reducers/views/dashboard.js
@@ -47,7 +47,7 @@ const updateLoadingStatus = (state) => {
     console.log("meetingLoaded UNZIPPED:", unzipped)
 
     let meetingLoaded = _.map(unzipped, (triple) => {
-        let bools = _.map(triple, (t) => { return !(t === false) });
+        let bools = _.map(triple, (t) => { return Boolean(t)});
         console.log("meetingLoaded mapped to bools:", bools)
         return _.every(bools);
     });

--- a/reducers/views/dashboard.js
+++ b/reducers/views/dashboard.js
@@ -57,14 +57,11 @@ const updateLoadingStatus = (state) => {
 
     logger.debug('meetingLoaded UNZIPPED:', unzipped);
 
-    const meetingLoaded = _.map(unzipped, (triple) => {
-        const bools = _.map(triple, (t) => {return Boolean(t);});
-        logger.debug('meetingLoaded mapped to bools:', bools);
-        return _.every(bools);
-    });
-
+    // a meeting is loaded if all processed datasets for the meeting exist
+    const meetingLoaded = unzipped.map((processedDatasets) => processedDatasets.every((dataset) => Boolean(dataset)));
     logger.debug('meetingLoaded', meetingLoaded);
-    const isLoadedArray = _.map(meetingLoaded, (m) => {return m ? 'loaded' : 'loading';});
+
+    const isLoadedArray = meetingLoaded.map((isLoaded) => {return isLoaded ? 'loaded' : 'loading';});
     return {
         ...state,
         statsStatus: isLoadedArray,
@@ -93,14 +90,16 @@ const dashboard = (state = initialState, action) => {
             shouldFetch: timeDiff,
         };
     }
-    case DashboardActionTypes.DASHBOARD_LOADING_ALL_MEETINGS:
+    case DashboardActionTypes.DASHBOARD_LOADING_ALL_MEETINGS: {
+        const numMeetings = state.meetings.length;
         return {
             ...state,
-            statsStatus: _.map(state.meetings, () => {return 'loading';}),
-            processedUtterances: _.map(state.meetings, () => {return false;}),
-            influenceData: _.map(state.meetings, () => {return false;}),
-            timelineData: _.map(state.meetings, () => {return false;}),
+            statsStatus: new Array(numMeetings).fill('loading'),
+            processedUtterances: new Array(numMeetings).fill(false),
+            influenceData: new Array(numMeetings).fill(false),
+            timelineData: new Array(numMeetings).fill(false),
         };
+    }
     case DashboardActionTypes.DASHBOARD_LOADING_ERROR:
         return {
             ...state,


### PR DESCRIPTION
#### Summary

Reduce load on client by preventing unnecessary re-renders. 

The meeting visualization should only update if the size changes, or if the data was previously unloaded and has become loaded.

Local tests result in a significant performance increase

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes
