### PR TITLE
fix getting participantUtterances keys

### DIFF
--- a/actions/views/dashboard.js
+++ b/actions/views/dashboard.js
@@ -247,7 +247,7 @@ const processUtterances = (utterances, meetingId) => {
     });
 
     // {'participant': mean length of utterances in seconds}
-    const meanLengthUtterances = participantUtterances.keys().reduce((meanU, k) => {
+    const meanLengthUtterances = Object.keys(participantUtterances).reduce((meanU, k) => {
         meanU[k] = lengthUtterances[k] / numUtterances[k];
         return meanU;
     }, {});


### PR DESCRIPTION
#### Summary
Last merge was attempting to use a keys() member function of `participantUtterances` instead
of `Object.keys()`.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
