### PR TITLE
mattermost-redux making riff the default theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10737,8 +10737,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:rifflearning/mattermost-redux#dd99d262263efc9d36da24f31fd25ee7f2cef879",
-      "from": "github:rifflearning/mattermost-redux#dd99d262263efc9d36da24f31fd25ee7f2cef879",
+      "version": "github:rifflearning/mattermost-redux#b74dc2585c5332811e207785ea2208e16624adb3",
+      "from": "github:rifflearning/mattermost-redux#b74dc2585c5332811e207785ea2208e16624adb3",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",
@@ -15268,9 +15268,8 @@
       "dev": true
     },
     "sibilant-webaudio": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/sibilant-webaudio/-/sibilant-webaudio-0.1.5.tgz",
-      "integrity": "sha512-/7hpK/HQY3/vKXro4Osw7OWVgSfVNFYcejP9UN4Clyke/HMfTnbpRJxQtiZlSDmkSNncaFA0Hsdp5TRkS9e2cA==",
+      "version": "github:rifflearning/sibilant#f62e2192ab2ab00f3a3dc4392af9c101329069d7",
+      "from": "github:rifflearning/sibilant#f62e2192ab2ab00f3a3dc4392af9c101329069d7",
       "requires": {
         "lodash": "^4.13.1",
         "microevent": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
     "material-icons-react": "^1.0.4",
-    "mattermost-redux": "github:rifflearning/mattermost-redux#dd99d262263efc9d36da24f31fd25ee7f2cef879",
+    "mattermost-redux": "github:rifflearning/mattermost-redux#b74dc2585c5332811e207785ea2208e16624adb3",
     "moment-timezone": "0.5.21",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",


### PR DESCRIPTION
#### Summary
This PR points to my [working fork of mattermost-redux](https://github.com/rifflearning/mattermost-redux/pull/5). If desired, this PR can be deployed to dev (or elsewhere?) to confirm the fix works, before merging the PR to mattermost-redux. However, once the mattermost-redux PR is merged, this one will need to be updated to reflect the new git hash in the mattermost-redux repo. 

There are no code changes in this PR -- only dependency updates.

#### Ticket Link
https://trello.com/c/W5XsP7gS/235-set-riff-theme-as-default-theme

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
