### PR TITLE
Fix/screen tiling

### DIFF
--- a/components/webrtc_view_bulma/PeerVideo.jsx
+++ b/components/webrtc_view_bulma/PeerVideo.jsx
@@ -18,9 +18,18 @@ class PeerVideo extends React.Component {
             this.video.style.setProperty('overflow', 'hidden');
             this.video.style.setProperty('display', 'block');
             this.video.style.setProperty('width', '100%');
-            this.video.style.setProperty('height', '100%');
             this.video.style.setProperty('margins', '5px');
             this.video.style.setProperty('border-radius', '5px');
+
+            // when we have less than four peers, we display them in one row.
+            // with more than four, we display them in two rows
+            // set height to account for this
+            if (this.props.peerLength < 4) {
+                this.video.style.setProperty('height', '85vh');
+            } else {
+                this.video.style.setProperty('height', '42vh');
+            }
+
             if (this.props.type === 'peer') {
                 // we don't want to clip any of the shared screen,
                 // so only apply this to peers
@@ -47,15 +56,6 @@ class PeerVideo extends React.Component {
         }
 
         let classes = 'videoContainer remotes column';
-
-        if (this.props.peerLength < 4) {
-            style.width = '100vh';
-            style.height = '80vh';
-        } else {
-            style.width = '50vh';
-            style.height = '40vh';
-            classes += ' is-narrow';
-        }
 
         return (
             <div

--- a/components/webrtc_view_bulma/PeerVideo.jsx
+++ b/components/webrtc_view_bulma/PeerVideo.jsx
@@ -1,6 +1,10 @@
 // Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint
+    header/header: "off",
+ */
+
 import React from 'react';
 
 import {logger} from '../../utils/riff';
@@ -55,7 +59,7 @@ class PeerVideo extends React.Component {
             style.borderBottomLeftRadius = '5px';
         }
 
-        let classes = 'videoContainer remotes column';
+        const classes = 'videoContainer remotes column';
 
         return (
             <div

--- a/components/webrtc_view_bulma/RemoteVideoContainer.jsx
+++ b/components/webrtc_view_bulma/RemoteVideoContainer.jsx
@@ -1,6 +1,11 @@
 // Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint
+    header/header: "off",
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+ */
+
 import React from 'react';
 
 import {logger} from '../../utils/riff';
@@ -29,7 +34,7 @@ class RemoteVideoContainer extends React.Component {
                     key={peer.id}
                     id={peer.id}
                     videoEl={peer.videoEl}
-                    type="peer"
+                    type='peer'
                     peerColor={peerColor}
                     peerLength={peerLength}
                 />
@@ -43,28 +48,28 @@ class RemoteVideoContainer extends React.Component {
         logger.debug('names:', this.props.chat.webRtcPeerDisplayNames);
         logger.debug('riff ids:', this.props.chat.webRtcRiffIds);
         const peerVideos = this.props.peers.map(this.peerVideo(peerLength));
-        if  (peerLength >= 4) {
+        if (peerLength >= 4) {
             // return the videos separated into two rows
             // this may not be the best way to do this,
             // but it's the one i thought of first and
             // code freeze is tomorrow :)
             return (
-                <div className="column">
-                    <div className="row">
-                        <div className="columns">
+                <div className='column'>
+                    <div className='row'>
+                        <div className='columns'>
                             {peerVideos.slice(0, peerLength / 2)}
                         </div>
                     </div>
-                    <div className="row" style={{paddingTop: '25px'}}>
-                        <div className="columns">
+                    <div className='row' style={{paddingTop: '25px'}}>
+                        <div className='columns'>
                             {peerVideos.slice(peerLength / 2)}
                         </div>
                     </div>
                 </div>
             );
-        } else {
-            return peerVideos;
         }
+
+        return peerVideos;
     }
 
     videos() {
@@ -81,8 +86,8 @@ class RemoteVideoContainer extends React.Component {
 
     render() {
         return (
-            <div className="remotes" id="remoteVideos">
-                <div ref="remotes" className="columns is-multiline is-centered is-mobile">
+            <div className='remotes' id='remoteVideos'>
+                <div ref='remotes' className='columns is-multiline is-centered is-mobile'>
                     {this.videos()}
                 </div>
             </div>

--- a/components/webrtc_view_bulma/RemoteVideoContainer.jsx
+++ b/components/webrtc_view_bulma/RemoteVideoContainer.jsx
@@ -42,7 +42,29 @@ class RemoteVideoContainer extends React.Component {
         logger.debug('rendering', peerLength, 'peers....', this.props.peers);
         logger.debug('names:', this.props.chat.webRtcPeerDisplayNames);
         logger.debug('riff ids:', this.props.chat.webRtcRiffIds);
-        return this.props.peers.map(this.peerVideo(peerLength));
+        const peerVideos = this.props.peers.map(this.peerVideo(peerLength));
+        if  (peerLength >= 4) {
+            // return the videos separated into two rows
+            // this may not be the best way to do this,
+            // but it's the one i thought of first and
+            // code freeze is tomorrow :)
+            return (
+                <div className="column">
+                    <div className="row">
+                        <div className="columns">
+                            {peerVideos.slice(0, peerLength / 2)}
+                        </div>
+                    </div>
+                    <div className="row" style={{paddingTop: '25px'}}>
+                        <div className="columns">
+                            {peerVideos.slice(peerLength / 2)}
+                        </div>
+                    </div>
+                </div>
+            );
+        } else {
+            return peerVideos;
+        }
     }
 
     videos() {
@@ -54,7 +76,6 @@ class RemoteVideoContainer extends React.Component {
                 />
             );
         }
-
         return this.addPeerVideos();
     }
 

--- a/components/webrtc_view_bulma/WebrtcSidebar.jsx
+++ b/components/webrtc_view_bulma/WebrtcSidebar.jsx
@@ -244,30 +244,27 @@ class WebRtcSidebar extends React.PureComponent {
     render() {
         return (
             <Menu>
-                {
-                    !this.props.inRoom ?
-                        <MenuLabelCentered>
-                            {'Check your video and microphone before joining.'}
-                        </MenuLabelCentered> :
-                        <MenuLabelCentered> {
-                            this.props.inRoom &&
-                            <LeaveRoomButton
-                                webrtc={this.props.webrtc}
-                                leaveRiffRoom={this.props.riffParticipantLeaveRoom}
-                                leaveRoom={this.props.leaveRoom}
-                            />
-                        }
-                        </MenuLabelCentered>
-                }
+                {!this.props.inRoom ? (
+                    <MenuLabelCentered>
+                        {'Check your video and microphone before joining.'}
+                    </MenuLabelCentered>
+                ) : (
+                    <MenuLabelCentered>
+                        <LeaveRoomButton
+                            webrtc={this.props.webrtc}
+                            leaveRiffRoom={this.props.riffParticipantLeaveRoom}
+                            leaveRoom={this.props.leaveRoom}
+                        />
+                    </MenuLabelCentered>
+                )}
 
                 {!this.props.webRtcLocalSharedScreen ? this.localVideo() : this.localSharedScreen()}
 
-                {
-                    this.props.mediaError &&
+                {this.props.mediaError && (
                     <VideoPlaceholder style={placeholderStyle(this.props.mediaError)}>
                         <p>{"Can't see your video? Make sure your camera is enabled."}</p>
                     </VideoPlaceholder>
-                }
+                )}
 
                 <p
                     className="menu-label"
@@ -278,11 +275,11 @@ class WebRtcSidebar extends React.PureComponent {
 
                 {this.props.inRoom && <AudioStatus {...this.props}/>}
 
-                {
-                    !this.props.inRoom ?
-                        <AudioStatusBar {...this.props}/> :
-                        <MeetingMediator {...this.props}/>
-                }
+                {!this.props.inRoom ? (
+                    <AudioStatusBar {...this.props}/>
+                ) : (
+                    <MeetingMediator {...this.props}/>
+                )}
             </Menu>
         );
     }

--- a/components/webrtc_view_bulma/webrtc.jsx
+++ b/components/webrtc_view_bulma/webrtc.jsx
@@ -56,63 +56,69 @@ class WebRtc extends Component {
     }
 
     reattachVideo(video) {
-      if (video == null) {
-        return;
-      }
-      try {
-        if (this.props.inRoom &&
-            this.webrtc &&
-            this.webrtc.webrtc.localStreams.length &&
-            video.srcObject == null) {
-          this.webrtc.reattachLocalVideo(video);
+        if (video == null) {
+            return;
         }
-      } catch (err) {
-        // it is possible webrtc state will change while re-rendering,
-        // which can break things
-        // we catch the exception here so we can recover
-        logger.debug(err);
-      }
-      
-      // creating ref for local video so we can pass down to children
-      this.localVideoRef = video;
+        try {
+            if (
+                this.props.inRoom &&
+                this.webrtc &&
+                this.webrtc.webrtc.localStreams.length &&
+                video.srcObject == null
+            ) {
+                this.webrtc.reattachLocalVideo(video);
+            }
+        } catch (err) {
+            // it is possible webrtc state will change while re-rendering,
+            // which can break things
+            // we catch the exception here so we can recover
+            logger.debug(err);
+        }
+
+        // creating ref for local video so we can pass down to children
+        this.localVideoRef = video;
     }
 
     render () {
         return (
-            <div id='app-content'
-                 className=''>
-              <div className="section">
-                <div className="columns is-fullheight">
-                  <div className="column is-3 is-sidebar-menu is-hidden-mobile">
-                  <WebRtcSidebar {...this.props}
-                                 webrtc={this.webrtc}
-                                 localVideoRef={this.localVideoRef}
-                                 reattachVideo={this.reattachVideo}/>
-                  </div>
-                  <div className="column">
-                  <RenderVideos inRoom={this.props.inRoom}
+            <div id='app-content' className=''>
+                <div className="section">
+                    <div className="columns is-fullheight">
+                        <div className="column is-3 is-sidebar-menu is-hidden-mobile">
+                            <WebRtcSidebar {...this.props}
+                                webrtc={this.webrtc}
+                                localVideoRef={this.localVideoRef}
+                                reattachVideo={this.reattachVideo}
+                            />
+                        </div>
+                        <div className="column">
+                            <RenderVideos
+                                inRoom={this.props.inRoom}
                                 roomName={this.props.roomName}
                                 handleKeyPress={this.props.handleKeyPress}
                                 webRtcPeers={this.props.webRtcPeers}
                                 handleRoomNameChange={null}
                                 handleReadyClick={(event) => this.props.handleReadyClick(event, this.props, this.webrtc)}
-                    joinButtonDisabled={false}
-                    clearJoinRoomError={this.props.clearJoinRoomError}
-                    joinRoomStatus={this.props.joinRoomStatus}
-                    joinRoomMessage={this.props.joinRoomMessage}
-                    chat={this.props}
-                    riff={this.props.riff}
-                    webrtc={this.webrtc}
-                    displayRoomName={false}
-                    displayName={this.props.user.nickname == "" ?
-                    "@" + this.props.user.username : this.props.user.nickname}
-                    roDisplayName={true}
-                    webRtcRemoteSharedScreen={this.props.webRtcRemoteSharedScreen}>
-                  </RenderVideos>
-                  {this.props.inRoom && <TextChat/>}
-                  </div>
+                                joinButtonDisabled={false}
+                                clearJoinRoomError={this.props.clearJoinRoomError}
+                                joinRoomStatus={this.props.joinRoomStatus}
+                                joinRoomMessage={this.props.joinRoomMessage}
+                                chat={this.props}
+                                riff={this.props.riff}
+                                webrtc={this.webrtc}
+                                displayRoomName={false}
+                                displayName={this.props.user.nickname == "" ? (
+                                    "@" + this.props.user.username
+                                ) : (
+                                    this.props.user.nickname
+                                )}
+                                roDisplayName={true}
+                                webRtcRemoteSharedScreen={this.props.webRtcRemoteSharedScreen}
+                            />
+                            {this.props.inRoom && <TextChat/>}
+                        </div>
+                    </div>
                 </div>
-              </div>
             </div>
         );
     }

--- a/components/webrtc_view_bulma/webrtc.jsx
+++ b/components/webrtc_view_bulma/webrtc.jsx
@@ -84,7 +84,7 @@ class WebRtc extends Component {
             <div id='app-content' className=''>
                 <div className="section">
                     <div className="columns is-fullheight">
-                        <div className="column is-3 is-sidebar-menu is-hidden-mobile">
+                        <div className="is-sidebar-menu">
                             <WebRtcSidebar {...this.props}
                                 webrtc={this.webrtc}
                                 localVideoRef={this.localVideoRef}


### PR DESCRIPTION
#### Summary
In a video chat with more than three other people, the videos will display in a nice grid within the confines of the screen. Previously, videos would be rendered outside of the screen space and it was a mess.

The actual size of the sidebar has been reduced to match the apparent size of the sidebar (no changes, visually, to the sidebar, however the videos will have more space to display)
Now, if there are more than three peers in a meeting, they will be moved into two rows. This should handle as many as 11 participants gracefully, but performance will likely degrade before then.

Also, cleaned up some style stuff while I was in there - I definitely missed some stuff, but I'll get to that when I do an actual pass on code cleanup.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes