### PR TITLE
remove log statements that show all messages to every room

### DIFF
--- a/components/webrtc_view_bulma/RiffListener.js
+++ b/components/webrtc_view_bulma/RiffListener.js
@@ -30,7 +30,6 @@ export default function () {
 
     app.service('participantEvents').on('created', function (obj) {
         let state = getState();
-        console.log('riff listener.participantEvents.created: entered', { obj, expectedRoom: state.views.webrtc.webRtcRoom });
         if (obj.meeting.room === state.views.webrtc.webRtcRoom) {
             console.log('riff listener.participantEvents.created: updating participants',
                          { from: state.views.riff.participants, to: obj.participants, obj });
@@ -43,7 +42,6 @@ export default function () {
     app.service('messages').on('created', function (obj) {
         let state = getState();
         let user = getCurrentUser(state);
-        console.log('riff listener.messages.created', obj, user.id, updateTextChat);
         if (obj.meeting === state.views.riff.meetingId &&
             obj.participant != user.id) {
             dispatch(updateTextChat(

--- a/components/webrtc_view_bulma/RiffListener.js
+++ b/components/webrtc_view_bulma/RiffListener.js
@@ -1,49 +1,67 @@
-import {app, socket} from '../../utils/riff';
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint
+    header/header: "off",
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" } }],
+ */
+
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+
 import {
     updateMeetingParticipants,
     updateTurnData,
-    updateRiffMeetingId} from '../../actions/views/riff';
-import {updateTextChat} from '../../actions/webrtc_actions';
-import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+    updateRiffMeetingId} from 'actions/views/riff';
+import {updateTextChat} from 'actions/webrtc_actions';
 import store from 'stores/redux_store.jsx';
-
+import {app, logger} from 'utils/riff';
 
 function transformTurns(participants, turns) {
-    let filteredTurns = turns.filter(turn => participants.includes(turn.participant));
+    const filteredTurns = turns.filter((turn) => participants.includes(turn.participant));
     return filteredTurns;
 }
 
-export default function () {
+export default function riffListener() {
     // this listener listens for events ~from~ the server
 
     const dispatch = store.dispatch;
     const getState = store.getState;
-    const state = getState()
-    app.service('turns').on('updated', function (obj) {
-        let state = getState();
+    app.service('turns').on('updated', (obj) => {
+        const state = getState();
         if (obj.room === state.views.webrtc.webRtcRoom && state.views.riff.participants.length > 1) {
-            console.log("Updating turns");
+            logger.debug('Updating turns');
             dispatch(updateTurnData(obj.transitions,
                                     transformTurns(state.views.riff.participants, obj.turns)));
         }
     });
 
-    app.service('participantEvents').on('created', function (obj) {
-        let state = getState();
+    app.service('participantEvents').on('created', (obj) => {
+        const state = getState();
+
+        // don't even debug log this unless actively needed as it currently displays all messages in
+        // any ongoing meeting.
+        // logger.debug('riff listener.participantEvents.created: entered', { obj, expectedRoom: state.views.webrtc.webRtcRoom });
+
         if (obj.meeting.room === state.views.webrtc.webRtcRoom) {
-            console.log('riff listener.participantEvents.created: updating participants',
-                         { from: state.views.riff.participants, to: obj.participants, obj });
+            logger.debug('riff listener.participantEvents.created: updating participants',
+                         {from: state.views.riff.participants, to: obj.participants, obj});
+
             // update meeting mediator data
             dispatch(updateMeetingParticipants(obj.participants));
-            dispatch(updateRiffMeetingId(obj.meeting._id));
+            dispatch(updateRiffMeetingId(obj.meeting._id)); // eslint-disable-line no-underscore-dangle
         }
     });
 
-    app.service('messages').on('created', function (obj) {
-        let state = getState();
-        let user = getCurrentUser(state);
+    app.service('messages').on('created', (obj) => {
+        const state = getState();
+        const user = getCurrentUser(state);
+
+        // don't even debug log this unless actively needed as it currently displays all messages in
+        // any ongoing meeting.
+        // logger.debug('riff listener.messages.created', obj, user.id, updateTextChat);
+
         if (obj.meeting === state.views.riff.meetingId &&
-            obj.participant != user.id) {
+            obj.participant !== user.id) {
             dispatch(updateTextChat(
                 obj.msg,
                 obj.meeting,

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -69,7 +69,7 @@ export const config = {
 
 // TODO: get the client log level from some real configuration sent from the server
 const configLogLevel = process.env.CLIENT_ENV ? process.env.CLIENT_ENV.RIFF_LOGLEVEL : process.env.RIFF_LOGLEVEL;
-config.logLevel = configLogLevel || 'debug';
+config.logLevel = configLogLevel || 'info';
 logger.setLogLevel(config.logLevel);
 
 // TODO: get the data server url and path from some real configuration sent from the server


### PR DESCRIPTION
Don't show messages from other rooms in the console, please

#### Summary
Remove log statements that allow users to easily see messages they are not supposed to see just by opening the console


