### PR TITLE
clean up gantt chart code

### DIFF
--- a/components/dashboard/components/TimelineChart.jsx
+++ b/components/dashboard/components/TimelineChart.jsx
@@ -13,7 +13,7 @@ import lifecycle from 'react-pure-lifecycle';
 
 import {logger, PeerColors} from 'utils/riff';
 
-import createGantt from './gantt';
+import {Gantt} from './gantt';
 import ChartCard from './ChartCard';
 
 const drawGantt = (props) => {
@@ -57,8 +57,9 @@ const drawGantt = (props) => {
         color: participantMap[u.participant].color,
     }));
 
-    var gantt = createGantt('#gantt-' + props.meeting._id, props.width).taskTypes(participantNames); // eslint-disable-line no-underscore-dangle
-    gantt(utts2);
+    const gantt = new Gantt(`#gantt-${props.meeting._id}`, props.width); // eslint-disable-line no-underscore-dangle
+    gantt.taskTypes = participantNames;
+    gantt.draw(utts2);
 };
 
 const componentDidMount = (props) => {
@@ -90,7 +91,7 @@ const chartInfo =
 // participants: [{id, name, ...}, ...]
 const TimelineView = (props) => {
     logger.debug('timeline props:', props);
-    var chartDiv;
+    let chartDiv;
     if (!props.loaded) { // eslint-disable-line no-negated-condition
         chartDiv = (
             <ScaleLoader color={'#8A6A94'}/>

--- a/components/dashboard/components/TimelineChart.jsx
+++ b/components/dashboard/components/TimelineChart.jsx
@@ -45,7 +45,7 @@ const drawGantt = (props) => {
             return pmap;
         }, participantMap);
 
-    const numOtherPeers = participantMap.length - (participantMap[participantId] ? 1 : 0);
+    const numOtherPeers = participants.length - (participantMap[participantId] ? 1 : 0);
     if (numOtherPeers > PeerColors.length - 1) {
         logger.warn(`Not enough colors (${PeerColors.length - 1}) for all peers (${numOtherPeers})`);
     }

--- a/components/dashboard/components/gantt.js
+++ b/components/dashboard/components/gantt.js
@@ -15,138 +15,209 @@ const TimeDomainMode = {
     FIXED: 'fixed',
 };
 
-function createGantt(selector, width) {
-    let margin = {
-        top: 20,
-        right: 50,
-        bottom: 20,
-        left: 50,
-    };
-    let timeDomainStart = d3.timeDay.offset(new Date(), -3);
-    let timeDomainEnd = d3.timeHour.offset(new Date(), +3);
-    let timeDomainMode = TimeDomainMode.FIT; // fixed or fit
-    let taskTypes = [];
-    let taskStatus = [];
+/* ******************************************************************************
+ * Gantt                                                                   */ /**
+ *
+ * The Gantt class uses d3 to draw a gantt chart of tasks organized by task type.
+ *
+ ********************************************************************************/
+export class Gantt {
+    /**
+     * Gantt class constructor.
+     *
+     * @param {string} selector
+     *      The selector for the element on the page which will be the parent
+     *      of the svg gantt chart that is drawn.
+     * @param {number} width
+     *      Width in pixels of the view area for the chart, the actual chart
+     *      will be offset within this width by the left and right margins.
+     */
+    constructor(selector, width) {
+        /** backing store for getter/setter properties */
+        this.privateProp = {};
 
-    logger.debug('DOCUMENT BODY WIDTH', document.body.clientWidth);
+        this.selector = selector;
+        this.margin = {
+            top: 20,
+            right: 50,
+            bottom: 20,
+            left: 50,
+        };
+        const initWidth = width || document.body.clientWidth / 2;
+        this.width = (initWidth - (initWidth / 5)) - this.margin.right - this.margin.left;
+        this.height = 250; // alternatively '100%'
+        this.timeDomain = [d3.timeDay.offset(new Date(), -3), d3.timeHour.offset(new Date(), +3)];
+        this.timeDomainMode = TimeDomainMode.FIT; // fixed or fit
+        this.taskTypes = [];
+        this.taskStatus = [];
+        this.tickFormat = '%H:%M';
 
-    //let height = document.body.clientHeight - margin.top - margin.bottom-5;
-    const initWidth = width || document.body.clientWidth / 2;
-    logger.debug('HAVE WIDTH FROM REF:', width, 'BODY WIDTH:', document.body.clientWidth / 2);
-    logger.debug('using init width:', initWidth);
-    width = (initWidth - (initWidth / 5)) - margin.right - margin.left;
-
-    //let width = '100%';
-    let height = 250;
-
-    //let width = 600;
-
-    let tickFormat = '%H:%M';
-
-    const keyFunction = (d) => {
-        return d.startDate + d.taskName + d.endDate;
-    };
-
-    const rectTransform = (d) => {
-        return 'translate(' + x(d.startDate) + ',' + y(d.taskName) + ')';
-    };
-
-    let x = d3
-        .scaleTime()
-        .domain([timeDomainStart, timeDomainEnd])
-        .range([0, width])
-        .clamp(true);
-
-    let y = d3
-        .scaleBand()
-        .domain(taskTypes)
-        .range([0, height - margin.top - margin.bottom], 0.1);
-
-    let xAxis = d3
-        .axisBottom(x)
-        .tickFormat(d3.timeFormat(tickFormat))
-        .tickSize(8)
-        .tickPadding(8)
-        .ticks(d3.timeMinute.every(15));
-
-    let yAxis = d3.axisLeft(y).tickSize(0);
-
-    const initTimeDomain = (tasks) => {
-        logger.debug('initializing time domain with tasks:', tasks);
-        if (timeDomainMode === TimeDomainMode.FIT) {
-            if (tasks === undefined || tasks.length < 1) { // eslint-disable-line no-undefined
-                timeDomainStart = d3.timeDay.offset(new Date(), -3);
-                timeDomainEnd = d3.timeHour.offset(new Date(), +3);
-                return;
-            }
-
-            // tasks.sort(function(a, b) {
-            //   return a.endDate - b.endDate;
-            // });
-            timeDomainEnd = tasks[tasks.length - 1].endDate;
-
-            // tasks.sort(function(a, b) {
-            //   return a.startDate - b.startDate;
-            // });
-            timeDomainStart = tasks[0].startDate;
-            logger.debug('time domain:', timeDomainStart, timeDomainEnd);
-        }
-    };
-
-    const initAxis = () => {
-        x = d3
+        this.x = d3
             .scaleTime()
-            .domain([timeDomainStart, timeDomainEnd])
-            .range([0, width])
+            .domain(this.timeDomain)
+            .range([0, this.width])
             .clamp(true);
-        y = d3
+
+        this.y = d3
             .scaleBand()
-            .domain(taskTypes)
-            .range([0, height - margin.top - margin.bottom], 0.1);
-        xAxis = d3
-            .axisBottom(x)
-            .tickFormat(d3.timeFormat(tickFormat))
+            .domain(this.taskTypes)
+            .range([0, this.height - this.margin.top - this.margin.bottom], 0.1);
+
+        this.xAxis = d3
+            .axisBottom(this.x)
+            .tickFormat(d3.timeFormat(this.tickFormat))
             .tickSize(8)
-            .tickPadding(8);
+            .tickPadding(8)
+            .ticks(d3.timeMinute.every(15)); // TODO: Why isn't this setting in initAxis?
 
-        yAxis = d3.axisLeft(y).tickSize(0);
-    };
+        this.yAxis = d3.axisLeft(this.y).tickSize(0);
 
-    function gantt(tasks) {
+        this.keyFunction = (d) => {
+            return d.startDate + d.taskName + d.endDate;
+        };
+
+        this.rectTransform = (d) => {
+            return 'translate(' + this.x(d.startDate) + ',' + this.y(d.taskName) + ')';
+        };
+    }
+
+    /*
+     * Gantt property getters/setters
+     */
+    get selector() {
+        return this.privateProp.selector;
+    }
+    set selector(sel) {
+        this.privateProp.selector = sel;
+    }
+
+    get width() {
+        return this.privateProp.width;
+    }
+    set width(w) {
+        this.privateProp.width = Number(w);
+    }
+
+    get height() {
+        return this.privateProp.height;
+    }
+    set height(h) {
+        this.privateProp.height = Number(h);
+    }
+
+    get margin() {
+        return this.privateProp.margin;
+    }
+    set margin(m) {
+        this.privateProp.margin = m;
+    }
+
+    get timeDomain() {
+        return [this.privateProp.timeDomainStart, this.privateProp.timeDomainEnd];
+    }
+    set timeDomain(td) {
+        this.privateProp.timeDomainStart = Number(td[0]);
+        this.privateProp.timeDomainEnd = Number(td[1]);
+    }
+
+    get tickFormat() {
+        return this.privateProp.tickFormat;
+    }
+    set tickFormat(fmt) {
+        this.privateProp.tickFormat = fmt;
+    }
+
+    /**
+     * @param {string} tdMode
+     *      - 'fit' - the domain fits the data
+     *      - 'fixed' - fixed domain
+     * @returns {string} current time domain mode
+     */
+    get timeDomainMode() {
+        return this.privateProp.timeDomainMode;
+    }
+    set timeDomainMode(tdMode) {
+        this.privateProp.timeDomainMode = tdMode;
+    }
+
+    get taskTypes() {
+        return this.privateProp.taskTypes;
+    }
+    set taskTypes(value) {
+        logger.debug('setting task types to:', value);
+        this.privateProp.taskTypes = value;
+    }
+
+    get taskStatus() {
+        return this.privateProp.taskStatus;
+    }
+    set taskStatus(status) {
+        this.privateProp.taskStatus = status;
+    }
+
+    /*
+     * chaining property setting functions
+     */
+    setSelector(sel) {
+        this.selector = sel;
+        return this;
+    }
+
+    setWidth(w) {
+        this.width = w;
+        return this;
+    }
+
+    setTaskTypes(types) {
+        this.taskTypes = types;
+        return this;
+    }
+
+    setTaskStatus(status) {
+        this.taskStatus = status;
+        return this;
+    }
+
+    /**
+     * draw the given tasks using the current set of task types
+     *
+     * @param {Array} tasks
+     */
+    draw(tasks) {
         logger.debug('tasks:', tasks);
 
-        initTimeDomain(tasks);
-        initAxis();
+        this.initTimeDomain(tasks);
+        this.initAxis();
 
+        const containerSize = {
+            height: this.height + this.margin.top + this.margin.bottom,
+            width: this.width + this.margin.left + this.margin.right,
+        };
         const svg = d3
-            .select(selector)
+            .select(this.selector)
             .append('svg')
             .attr('class', 'chart')
-            .attr('width', width + margin.left + margin.right)
-            .attr('height', height + margin.top + margin.bottom)
+            .attr('width', containerSize.width)
+            .attr('height', containerSize.height)
             .append('g')
             .attr('class', 'gantt-chart')
             .attr('role', 'figure')
             .attr('aria-labelledby', 'gantt-label')
-
-            .attr('width', width + margin.left + margin.right)
-            .attr('height', height + margin.top + margin.bottom)
-            .attr(
-                'transform',
-                'translate(' + margin.left + ', ' + margin.top + ')'
-            );
+            .attr('width', containerSize.width)
+            .attr('height', containerSize.height)
+            .attr('transform', `translate(${this.margin.left}, ${this.margin.top})`);
 
         svg.append('title')
             .attr('id', 'gantt-label')
             .text('Timeline Chart');
 
         svg.selectAll('.chart')
-            .data(tasks, keyFunction)
+            .data(tasks, this.keyFunction)
             .enter()
             .append('g')
             .attr('role', 'presentation')
             .attr('aria-label', (d) => {
-                const startTime = d3.timeFormat(tickFormat)(d.startDate);
+                const startTime = d3.timeFormat(this.tickFormat)(d.startDate);
                 const utteranceLength = Math.round((d.endDate - d.startDate) / 1000);
                 return `${startTime}, ${d.taskName} spoke for ${utteranceLength} seconds`;
             })
@@ -154,18 +225,16 @@ function createGantt(selector, width) {
             .attr('rx', 5)
             .attr('ry', 5)
             .attr('class', (d) => {
-                if (taskStatus[d.status] === null) {
+                if (this.taskStatus[d.status] === null) {
                     return 'bar';
                 }
-                return taskStatus[d.status];
+                return this.taskStatus[d.status];
             })
             .attr('y', 0)
-            .attr('transform', rectTransform)
-            .attr('height', (d) => {
-                return y.bandwidth();
-            })
+            .attr('transform', this.rectTransform)
+            .attr('height', this.y.bandwidth())
             .attr('width', (d) => {
-                return Math.max(1, x(d.endDate) - x(d.startDate));
+                return Math.max(1, this.x(d.endDate) - this.x(d.startDate));
             })
             .attr('fill', (d) => {
                 return d.color;
@@ -175,157 +244,114 @@ function createGantt(selector, width) {
             .attr('class', 'x axis')
             .attr('class', 'axisGray')
             .attr('aria-hidden', 'true')
-            .attr(
-                'transform',
-                'translate(0, ' + (height - margin.top - margin.bottom) + ')'
-            )
+            .attr('transform', `translate(0, ${this.height - this.margin.top - this.margin.bottom})`)
             .transition()
-            .call(xAxis);
+            .call(this.xAxis);
 
         svg.append('g')
             .attr('class', 'y axis')
             .attr('class', 'axisGray')
             .attr('aria-hidden', 'true')
             .transition()
-            .call(yAxis);
+            .call(this.yAxis);
 
-        logger.debug('gantt looks like:', gantt);
-        return gantt;
+        return this;
     }
 
-    gantt.redraw = (tasks) => {
-        initTimeDomain(tasks);
-        initAxis();
+    redraw(tasks) {
+        this.initTimeDomain(tasks);
+        this.initAxis();
 
         const svg = d3.select('.chart');
 
         const ganttChartGroup = svg.select('.gantt-chart');
-        const rect = ganttChartGroup.selectAll('rect').data(tasks, keyFunction);
+        const rect = ganttChartGroup.selectAll('rect').data(tasks, this.keyFunction);
 
         rect.enter()
             .insert('rect', ':first-child')
             .attr('rx', 5)
             .attr('ry', 5)
             .attr('class', (d) => {
-                if (taskStatus[d.status] == null) {
+                if (this.taskStatus[d.status] == null) {
                     return 'bar';
                 }
-                return taskStatus[d.status];
+                return this.taskStatus[d.status];
             })
             .transition()
             .attr('y', 0)
-            .attr('transform', rectTransform)
-            .attr('height', (d) => {
-                return y.bandwidth();
-            })
+            .attr('transform', this.rectTransform)
+            .attr('height', this.y.bandwidth())
             .attr('width', (d) => {
-                return Math.max(1, x(d.endDate) - x(d.startDate));
+                return Math.max(1, this.x(d.endDate) - this.x(d.startDate));
             })
             .attr('fill', (d) => {
                 return d.color;
             });
 
         rect.transition()
-            .attr('transform', rectTransform)
-            .attr('height', (d) => {
-                return y.bandwidth();
-            })
+            .attr('transform', this.rectTransform)
+            .attr('height', this.y.bandwidth())
             .attr('width', (d) => {
-                return Math.max(1, x(d.endDate) - x(d.startDate));
+                return Math.max(1, this.x(d.endDate) - this.x(d.startDate));
             });
 
         rect.exit().remove();
 
         svg.select('.x')
             .transition()
-            .call(xAxis);
+            .call(this.xAxis);
         svg.select('.y')
             .transition()
-            .call(yAxis);
+            .call(this.yAxis);
 
-        return gantt;
-    };
-
-    gantt.margin = function(value) {
-        if (!arguments.length) {
-            return margin;
-        }
-        margin = value;
-        return gantt;
-    };
-
-    gantt.timeDomain = function(value) {
-        if (!arguments.length) {
-            return [timeDomainStart, timeDomainEnd];
-        }
-        timeDomainStart = Number(value[0]);
-        timeDomainEnd = Number(value[1]);
-        return gantt;
-    };
+        return this;
+    }
 
     /**
-     * @param {string}
-     *                vale The value can be "fit" - the domain fits the data or
-     *                "fixed" - fixed domain.
+     * set the time domain start and end values based on the given tasks
+     * and the current time domain mode.
      */
-    gantt.timeDomainMode = function(value) {
-        if (!arguments.length) {
-            return timeDomainMode;
+    initTimeDomain(tasks) {
+        logger.debug('initializing time domain with tasks:', tasks);
+        let timeDomainStart;
+        let timeDomainEnd;
+        if (this.timeDomainMode === TimeDomainMode.FIT) {
+            if (tasks === undefined || tasks.length < 1) { // eslint-disable-line no-undefined
+                timeDomainStart = [d3.timeDay.offset(new Date(), -3), d3.timeHour.offset(new Date(), +3)];
+                timeDomainEnd = [d3.timeDay.offset(new Date(), -3), d3.timeHour.offset(new Date(), +3)];
+            } else {
+                // TODO: need the earliest startDate and the latest endDate, depending on how the tasks
+                // overlap that may not be the start of the first and the end of the last. Check!
+                timeDomainStart = tasks[0].startDate;
+                timeDomainEnd = tasks[tasks.length - 1].endDate;
+            }
+            this.timeDomain = [timeDomainStart, timeDomainEnd];
+            logger.debug('Gantt time domain:', {timeDomainStart, timeDomainEnd});
         }
-        timeDomainMode = value;
-        return gantt;
-    };
+    }
 
-    gantt.taskTypes = function(value) {
-        if (!arguments.length) {
-            return taskTypes;
-        }
-        logger.debug('setting task types to:', value);
-        taskTypes = value;
-        return gantt;
-    };
+    /**
+     * set the x, y, xAxis and yAxis d3 functions based on the current values
+     * of time domain, width, height, margins...
+     */
+    initAxis() {
+        this.x = d3
+            .scaleTime()
+            .domain(this.timeDomain)
+            .range([0, this.width])
+            .clamp(true);
 
-    gantt.taskStatus = function(value) {
-        if (!arguments.length) {
-            return taskStatus;
-        }
-        taskStatus = value;
-        return gantt;
-    };
+        this.y = d3
+            .scaleBand()
+            .domain(this.taskTypes)
+            .range([0, this.height - this.margin.top - this.margin.bottom], 0.1);
 
-    gantt.width = function(value) {
-        if (!arguments.length) {
-            return width;
-        }
-        width = Number(value);
-        return gantt;
-    };
+        this.xAxis = d3
+            .axisBottom(this.x)
+            .tickFormat(d3.timeFormat(this.tickFormat))
+            .tickSize(8)
+            .tickPadding(8);
 
-    gantt.height = function(value) {
-        if (!arguments.length) {
-            return height;
-        }
-        height = Number(value);
-        return gantt;
-    };
-
-    gantt.tickFormat = function(value) {
-        if (!arguments.length) {
-            return tickFormat;
-        }
-        tickFormat = value;
-        return gantt;
-    };
-
-    gantt.selector = function(value) {
-        if (!arguments.length) {
-            return selector;
-        }
-        selector = value;
-        return gantt;
-    };
-
-    return gantt;
+        this.yAxis = d3.axisLeft(this.y).tickSize(0);
+    }
 }
-
-export default createGantt;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11017,6 +11017,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -15285,9 +15286,9 @@
       "version": "github:jordanreedie/SimpleWebRTC#1e11df8f0f58afbaef73da877d15013519555403",
       "from": "github:jordanreedie/SimpleWebRTC#feature/screen-sharing",
       "requires": {
-        "attachmediastream": "github:jordanreedie/attachMediaStream#889613872dae1a46eacade0f07e5e0c8b637e848",
+        "attachmediastream": "github:jordanreedie/attachMediaStream#master",
         "filetransfer": "^2.0.4",
-        "localmedia": "github:jordanreedie/localmedia#62adc5be5e1bbaac5fa7b2e8ebfaf0a6bacffa2f",
+        "localmedia": "github:jordanreedie/localmedia#feature/update-get-screen",
         "mockconsole": "0.0.1",
         "rtcpeerconnection": "^8.0.0",
         "socket.io-client": "^1.7.4",
@@ -18660,7 +18661,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
       "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "yargs": {
       "version": "3.32.0",


### PR DESCRIPTION
#### Summary
- fixed most of the style errors in `gantt.js`
- then rewrote the internals of gantt.js so instead of exporting a function it exports a Gantt class
- fixed the timeline chart warning messages when there are more peers than colors

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
