### PR TITLE
Fix replying to a message (remove experimental webrtc vestiges)

### DIFF
--- a/components/post_profile_picture/post_profile_picture.jsx
+++ b/components/post_profile_picture/post_profile_picture.jsx
@@ -16,7 +16,6 @@ export default class PostProfilePicture extends React.PureComponent {
         compactDisplay: PropTypes.bool.isRequired,
         enablePostIconOverride: PropTypes.bool.isRequired,
         hasImageProxy: PropTypes.bool.isRequired,
-        isBusy: PropTypes.bool,
         isRHS: PropTypes.bool,
         post: PropTypes.object.isRequired,
         status: PropTypes.string,
@@ -72,7 +71,6 @@ export default class PostProfilePicture extends React.PureComponent {
         return (
             <ProfilePicture
                 hasMention={hasMention}
-                isBusy={this.props.isBusy}
                 isRHS={this.props.isRHS}
                 src={src}
                 status={status}

--- a/components/profile_picture.jsx
+++ b/components/profile_picture.jsx
@@ -24,7 +24,6 @@ export default class ProfilePicture extends React.PureComponent {
         width: PropTypes.string,
         height: PropTypes.string,
         user: PropTypes.object,
-        isBusy: PropTypes.bool,
         isRHS: PropTypes.bool,
         hasMention: PropTypes.bool,
     };
@@ -47,7 +46,6 @@ export default class ProfilePicture extends React.PureComponent {
                                 user={this.props.user}
                                 src={this.props.src}
                                 status={this.props.status}
-                                isBusy={this.props.isBusy}
                                 hide={this.hideProfilePopover}
                                 isRHS={this.props.isRHS}
                                 hasMention={this.props.hasMention}

--- a/components/profile_popover/profile_popover.jsx
+++ b/components/profile_popover/profile_popover.jsx
@@ -90,10 +90,6 @@ class ProfilePopover extends React.Component {
             return true;
         }
 
-        if (nextProps.isBusy !== this.props.isBusy) {
-            return true;
-        }
-
         // React-Bootstrap Forwarded Props from OverlayTrigger to Popover
         if (nextProps.arrowOffsetLeft !== this.props.arrowOffsetLeft) {
             return true;
@@ -173,7 +169,6 @@ class ProfilePopover extends React.Component {
         delete popoverProps.user;
         delete popoverProps.src;
         delete popoverProps.status;
-        delete popoverProps.isBusy;
         delete popoverProps.hide;
         delete popoverProps.isRHS;
         delete popoverProps.hasMention;

--- a/components/rhs_comment/rhs_comment.jsx
+++ b/components/rhs_comment/rhs_comment.jsx
@@ -40,7 +40,6 @@ export default class RhsComment extends React.Component {
         compactDisplay: PropTypes.bool,
         isFlagged: PropTypes.bool,
         status: PropTypes.string,
-        isBusy: PropTypes.bool,
         removePost: PropTypes.func.isRequired,
         previewCollapsed: PropTypes.string.isRequired,
         previewEnabled: PropTypes.bool.isRequired,
@@ -65,10 +64,6 @@ export default class RhsComment extends React.Component {
 
     shouldComponentUpdate(nextProps, nextState) {
         if (nextProps.status !== this.props.status) {
-            return true;
-        }
-
-        if (nextProps.isBusy !== this.props.isBusy) {
             return true;
         }
 
@@ -245,7 +240,6 @@ export default class RhsComment extends React.Component {
             <UserProfile
                 user={this.props.user}
                 status={status}
-                isBusy={this.props.isBusy}
                 isRHS={true}
                 hasMention={true}
             />
@@ -255,7 +249,6 @@ export default class RhsComment extends React.Component {
             profilePicture = (
                 <PostProfilePicture
                     compactDisplay={this.props.compactDisplay}
-                    isBusy={this.props.isBusy}
                     isRHS={true}
                     post={post}
                     status={this.props.status}
@@ -295,7 +288,6 @@ export default class RhsComment extends React.Component {
                         <UserProfile
                             user={this.props.user}
                             status={status}
-                            isBusy={this.props.isBusy}
                             isRHS={true}
                             hasMention={true}
                         />

--- a/components/rhs_root_post/rhs_root_post.jsx
+++ b/components/rhs_root_post/rhs_root_post.jsx
@@ -40,7 +40,6 @@ export default class RhsRootPost extends React.Component {
         status: PropTypes.string,
         previewCollapsed: PropTypes.string,
         previewEnabled: PropTypes.bool,
-        isBusy: PropTypes.bool,
         isEmbedVisible: PropTypes.bool,
         enableEmojiPicker: PropTypes.bool.isRequired,
         enablePostUsernameOverride: PropTypes.bool.isRequired,
@@ -66,10 +65,6 @@ export default class RhsRootPost extends React.Component {
 
     shouldComponentUpdate(nextProps, nextState) {
         if (nextProps.status !== this.props.status) {
-            return true;
-        }
-
-        if (nextProps.isBusy !== this.props.isBusy) {
             return true;
         }
 
@@ -289,7 +284,6 @@ export default class RhsRootPost extends React.Component {
                 <UserProfile
                     user={user}
                     status={this.props.status}
-                    isBusy={this.props.isBusy}
                     isRHS={true}
                     hasMention={true}
                 />
@@ -358,7 +352,6 @@ export default class RhsRootPost extends React.Component {
                     <div className='post__img'>
                         <PostProfilePicture
                             compactDisplay={this.props.compactDisplay}
-                            isBusy={this.props.isBusy}
                             isRHS={true}
                             post={post}
                             status={this.props.status}

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -54,7 +54,6 @@ export default class RhsThread extends React.Component {
         channel: PropTypes.object.isRequired,
         selected: PropTypes.object.isRequired,
         previousRhsState: PropTypes.string,
-        isWebrtc: PropTypes.bool,
         currentUser: PropTypes.object.isRequired,
         previewCollapsed: PropTypes.string.isRequired,
         previewEnabled: PropTypes.bool.isRequired,
@@ -78,7 +77,6 @@ export default class RhsThread extends React.Component {
             flaggedPosts: PreferenceStore.getCategory(Constants.Preferences.CATEGORY_FLAGGED_POST),
             statuses: Object.assign({}, UserStore.getStatuses()),
             previewsCollapsed: PreferenceStore.get(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.COLLAPSE_DISPLAY, 'false'),
-            isBusy: WebrtcStore.isBusy(),
             isScrolling: false,
             topRhsPostCreateAt: 0,
             openTime,
@@ -89,7 +87,6 @@ export default class RhsThread extends React.Component {
         PreferenceStore.addChangeListener(this.onPreferenceChange);
         UserStore.addChangeListener(this.onUserChange);
         UserStore.addStatusesChangeListener(this.onStatusChange);
-        WebrtcStore.addBusyListener(this.onBusy);
 
         this.scrollToBottom();
         window.addEventListener('resize', this.handleResize);
@@ -99,7 +96,6 @@ export default class RhsThread extends React.Component {
         PreferenceStore.removeChangeListener(this.onPreferenceChange);
         UserStore.removeChangeListener(this.onUserChange);
         UserStore.removeStatusesChangeListener(this.onStatusChange);
-        WebrtcStore.removeBusyListener(this.onBusy);
 
         window.removeEventListener('resize', this.handleResize);
     }
@@ -164,10 +160,6 @@ export default class RhsThread extends React.Component {
             return true;
         }
 
-        if (nextState.isBusy !== this.state.isBusy) {
-            return true;
-        }
-
         if (nextState.isScrolling !== this.state.isScrolling) {
             return true;
         }
@@ -199,10 +191,6 @@ export default class RhsThread extends React.Component {
 
     onStatusChange = () => {
         this.setState({statuses: Object.assign({}, UserStore.getStatuses())});
-    }
-
-    onBusy = (isBusy) => {
-        this.setState({isBusy});
     }
 
     filterPosts = (posts, selected, openTime) => {
@@ -431,7 +419,6 @@ export default class RhsThread extends React.Component {
                 />
                 <RhsHeaderPost
                     previousRhsState={this.props.previousRhsState}
-                    isWebrtc={this.props.isWebrtc}
                 />
                 <Scrollbars
                     autoHide={true}

--- a/components/rhs_thread/rhs_thread.jsx
+++ b/components/rhs_thread/rhs_thread.jsx
@@ -354,7 +354,6 @@ export default class RhsThread extends React.Component {
                     compactDisplay={this.state.compactDisplay}
                     isFlagged={isFlagged}
                     status={status}
-                    isBusy={this.state.isBusy}
                     removePost={this.props.actions.removePost}
                     previewCollapsed={this.props.previewCollapsed}
                     previewEnabled={this.props.previewEnabled}
@@ -443,7 +442,6 @@ export default class RhsThread extends React.Component {
                             status={rootStatus}
                             previewCollapsed={this.props.previewCollapsed}
                             previewEnabled={this.props.previewEnabled}
-                            isBusy={this.state.isBusy}
                         />
                         {isFakeDeletedPost && <DateSeparator date={rootPostDay}/>}
                         <div

--- a/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
+++ b/components/sidebar/header/dropdown/sidebar_header_dropdown.jsx
@@ -12,7 +12,7 @@ import {Permissions} from 'mattermost-redux/constants';
 
 import * as GlobalActions from 'actions/global_actions.jsx';
 import TeamStore from 'stores/team_store.jsx';
-import {Constants, WebrtcActionTypes} from 'utils/constants.jsx';
+import {Constants} from 'utils/constants.jsx';
 import {useSafeUrl} from 'utils/url';
 import * as UserAgent from 'utils/user_agent.jsx';
 import AboutBuildModal from 'components/about_build_modal';
@@ -79,8 +79,6 @@ export default class SidebarHeaderDropdown extends React.Component {
 
         this.renderCustomEmojiLink = this.renderCustomEmojiLink.bind(this);
 
-        this.handleClick = this.handleClick.bind(this);
-
         this.state = {
             teamMembers: TeamStore.getMyTeamMembers(),
             teamListings: TeamStore.getTeamListings(),
@@ -89,13 +87,6 @@ export default class SidebarHeaderDropdown extends React.Component {
             showTeamMembersModal: false,
             showAddUsersToTeamModal: false,
         };
-    }
-
-    handleClick(e) {
-        if (WebrtcStore.isBusy()) {
-            WebrtcStore.emitChanged({action: WebrtcActionTypes.IN_PROGRESS});
-            e.preventDefault();
-        }
     }
 
     toggleDropdown = (val) => {
@@ -224,7 +215,6 @@ export default class SidebarHeaderDropdown extends React.Component {
             <li>
                 <Link
                     id='customEmoji'
-                    onClick={this.handleClick}
                     to={'/' + this.props.teamName + '/emoji'}
                 >
                     <FormattedMessage
@@ -394,7 +384,6 @@ export default class SidebarHeaderDropdown extends React.Component {
                         <Link
                             id='Integrations'
                             to={'/' + this.props.teamName + '/integrations'}
-                            onClick={this.handleClick}
                         >
                             <FormattedMessage
                                 id='navbar_dropdown.integrations'
@@ -412,7 +401,6 @@ export default class SidebarHeaderDropdown extends React.Component {
                     <Link
                         id='systemConsole'
                         to={'/admin_console'}
-                        onClick={this.handleClick}
                     >
                         <FormattedMessage
                             id='navbar_dropdown.console'
@@ -436,7 +424,6 @@ export default class SidebarHeaderDropdown extends React.Component {
                         id='createTeam'
                         key='newTeam_a'
                         to='/create_team'
-                        onClick={this.handleClick}
                     >
                         <FormattedMessage
                             id='navbar_dropdown.create'
@@ -465,7 +452,6 @@ export default class SidebarHeaderDropdown extends React.Component {
                     <li key='joinTeam_li'>
                         <Link
                             id='joinAnotherTeam'
-                            onClick={this.handleClick}
                             to='/select_team'
                         >
                             <FormattedMessage

--- a/components/sidebar_right/sidebar_right.jsx
+++ b/components/sidebar_right/sidebar_right.jsx
@@ -138,7 +138,6 @@ export default class SidebarRight extends React.Component {
                     <div className='search-bar__container channel-header alt'>{searchForm}</div>
                     <RhsThread
                         previousRhsState={previousRhsState}
-                        isWebrtc={WebrtcStore.isBusy()}
                         currentUser={currentUser}
                         toggleSize={this.toggleSize}
                         shrink={this.onShrink}

--- a/components/sidebar_right_menu/sidebar_right_menu.jsx
+++ b/components/sidebar_right_menu/sidebar_right_menu.jsx
@@ -14,7 +14,6 @@ import TeamStore from 'stores/team_store.jsx';
 import UserStore from 'stores/user_store.jsx';
 import {
     Constants,
-    WebrtcActionTypes,
 } from 'utils/constants.jsx';
 import {useSafeUrl} from 'utils/url.jsx';
 import * as UserAgent from 'utils/user_agent.jsx';
@@ -79,13 +78,6 @@ export default class SidebarRightMenu extends React.Component {
     componentWillUnmount() {
         TeamStore.removeChangeListener(this.onChange);
         PreferenceStore.removeChangeListener(this.onChange);
-    }
-
-    handleClick = (e) => {
-        if (WebrtcStore.isBusy()) {
-            WebrtcStore.emitChanged({action: WebrtcActionTypes.IN_PROGRESS});
-            e.preventDefault();
-        }
     }
 
     handleAboutModal = () => {
@@ -279,7 +271,6 @@ export default class SidebarRightMenu extends React.Component {
                             id='createTeam'
                             key='newTeam_a'
                             to='/create_team'
-                            onClick={this.handleClick}
                         >
                             <i className='icon fa fa-plus-square'/>
                             <FormattedMessage
@@ -389,7 +380,6 @@ export default class SidebarRightMenu extends React.Component {
                     <li>
                         <Link
                             to={'/admin_console'}
-                            onClick={this.handleClick}
                         >
                             <i className='icon fa fa-wrench'/>
                             <FormattedMessage

--- a/components/user_profile.jsx
+++ b/components/user_profile.jsx
@@ -42,10 +42,6 @@ export default class UserProfile extends React.Component {
             return true;
         }
 
-        if (nextProps.isBusy !== this.props.isBusy) {
-            return true;
-        }
-
         return false;
     }
 
@@ -81,7 +77,6 @@ export default class UserProfile extends React.Component {
                             user={this.props.user}
                             src={profileImg}
                             status={this.props.status}
-                            isBusy={this.props.isBusy}
                             hide={this.hideProfilePopover}
                             isRHS={this.props.isRHS}
                             hasMention={this.props.hasMention}
@@ -114,7 +109,6 @@ UserProfile.propTypes = {
     disablePopover: PropTypes.bool,
     displayNameType: PropTypes.string,
     status: PropTypes.string,
-    isBusy: PropTypes.bool,
     isRHS: PropTypes.bool,
     hasMention: PropTypes.bool,
 };

--- a/tests/components/leave_team_modal/leave_team_modal.test.jsx
+++ b/tests/components/leave_team_modal/leave_team_modal.test.jsx
@@ -12,7 +12,6 @@ describe('components/LeaveTeamModal', () => {
         currentTeamId: 'team_id',
         onHide: jest.fn(),
         show: false,
-        isBusy: false,
         actions: {
             removeUserFromTeam: jest.fn(),
             toggleSideBarRightMenu: jest.fn(),

--- a/tests/components/profile_picture.test.jsx
+++ b/tests/components/profile_picture.test.jsx
@@ -10,7 +10,6 @@ describe('components/ProfilePicture', () => {
     const baseProps = {
         src: 'http://example.com/image.png',
         status: 'away',
-        isBusy: true,
     };
 
     test('should match snapshot, no user specified, default props', () => {

--- a/tests/components/search_results_item.test.jsx
+++ b/tests/components/search_results_item.test.jsx
@@ -77,7 +77,6 @@ describe('components/SearchResultsItem', () => {
             term: 'test',
             isMentionSearch: false,
             isFlagged: true,
-            isBusy: false,
             status: 'hello',
             enablePostUsernameOverride: false,
             actions: {


### PR DESCRIPTION
#### Summary
Removed experimental Webrtc vestiges. There were still some references to the
WebrtcStore which no longer exists, and that showed up when attempting to reply
to a message. The entire screen was wiped out instead of bringing up the sidebar
to enter a reply/start a reply thread.

At the same time it was noticed that the this was also being used for the `isBusy` property
which was being passed around, so references to that property have also been
removed.

#### Ticket Link
[Trello card #260](https://trello.com/c/q3B2QANU)

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
