### PR TITLE
Fix/side panel icons

### DIFF
--- a/components/search_results_header/search_results_header.jsx
+++ b/components/search_results_header/search_results_header.jsx
@@ -95,44 +95,40 @@ export default class SearchResultsHeader extends React.Component {
                         <OverlayTrigger
                             trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
-                            placement='top'
+                            placement='bottom'
                             overlay={expandSidebarTooltip}
                         >
                             <i
                                 className='fa fa-expand'
-                                title={localizeMessage('rhs_header.expandSidebarTooltip.icon', 'Expand Sidebar Icon')}
                             />
                         </OverlayTrigger>
                         <OverlayTrigger
                             trigger={['hover', 'focus']}
                             delayShow={Constants.OVERLAY_TIME_DELAY}
-                            placement='top'
+                            placement='bottom'
                             overlay={shrinkSidebarTooltip}
-                        >
-                            <i
-                                className='fa fa-compress'
-                                title={localizeMessage('rhs_header.expandTooltip.icon', 'Shrink Sidebar Icon')}
-                            />
+                         >
+                             <i
+                                 className='fa fa-compress'
+                             />
                         </OverlayTrigger>
                     </button>
                     <button
                         type='button'
                         className='sidebar--right__close'
                         aria-label='Close'
-                        title='Close'
                         onClick={this.props.actions.closeRightHandSide}
                     >
                         <OverlayTrigger
-                            trigger={['hover', 'focus']}
-                            delayShow={Constants.OVERLAY_TIME_DELAY}
-                            placement='top'
-                            overlay={closeSidebarTooltip}
-                        >
-                            <i
-                                className='fa fa-sign-out'
-                                title={localizeMessage('rhs_header.closeTooltip.icon', 'Close Sidebar Icon')}
-                            />
-                        </OverlayTrigger>
+                              trigger={['hover', 'focus']}
+                              delayShow={Constants.OVERLAY_TIME_DELAY}
+                              placement='bottom'
+                              overlay={closeSidebarTooltip}
+                          >
+                              <i
+                                  className='fa fa-sign-out'
+                              />
+                          </OverlayTrigger>
                     </button>
                 </div>
             </div>

--- a/components/search_results_header/search_results_header.jsx
+++ b/components/search_results_header/search_results_header.jsx
@@ -7,7 +7,6 @@ import {OverlayTrigger, Tooltip} from 'react-bootstrap';
 import {FormattedMessage} from 'react-intl';
 
 import Constants from 'utils/constants.jsx';
-import {localizeMessage} from 'utils/utils.jsx';
 
 export default class SearchResultsHeader extends React.Component {
     static propTypes = {
@@ -107,10 +106,10 @@ export default class SearchResultsHeader extends React.Component {
                             delayShow={Constants.OVERLAY_TIME_DELAY}
                             placement='bottom'
                             overlay={shrinkSidebarTooltip}
-                         >
-                             <i
-                                 className='fa fa-compress'
-                             />
+                        >
+                            <i
+                                className='fa fa-compress'
+                            />
                         </OverlayTrigger>
                     </button>
                     <button
@@ -120,15 +119,15 @@ export default class SearchResultsHeader extends React.Component {
                         onClick={this.props.actions.closeRightHandSide}
                     >
                         <OverlayTrigger
-                              trigger={['hover', 'focus']}
-                              delayShow={Constants.OVERLAY_TIME_DELAY}
-                              placement='bottom'
-                              overlay={closeSidebarTooltip}
-                          >
-                              <i
-                                  className='fa fa-sign-out'
-                              />
-                          </OverlayTrigger>
+                            trigger={['hover', 'focus']}
+                            delayShow={Constants.OVERLAY_TIME_DELAY}
+                            placement='bottom'
+                            overlay={closeSidebarTooltip}
+                        >
+                            <i
+                                className='fa fa-sign-out'
+                            />
+                        </OverlayTrigger>
                     </button>
                 </div>
             </div>


### PR DESCRIPTION
#### Summary
Removed titles from the fullscreen and close sidebar icons, as well as the button that was containing the close sidebar icon. These titles were creating tooltips additional to the ones provided by the `<OverlayTrigger />` component. The other solution would be to remove this component, and leave the titles...but I opted for this because the tooltip styles remained consistent with the navbar. 

#### Ticket Link
https://trello.com/c/nqXXNLOj/259-side-panel-flickers-and-does-not-respond-well-to-clicking

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes
