### PR TITLE
Fix/dashboard loading

### DIFF
--- a/components/dashboard/DashboardView.jsx
+++ b/components/dashboard/DashboardView.jsx
@@ -24,7 +24,6 @@ const LoadingErrorMessage = styled.div.attrs({
     text-align: center;
     color: #4A4A4A;
     font-size: 28px;
-    width: 40vw;
 `;
 
 // TODO Add dispatch and click
@@ -46,13 +45,14 @@ const DashboardView = (props) => {
     });
     const component = () => {
 
-        //errored
+        //errored (catch all static message is shown, these errors are all related to having no meetings)
         if (props.loadingError.status) {
             return (
                 <LoadingErrorMessage>
                     <div>Welcome to your Riff Dashboard!</div>
                     <br/>
-                    <div >{props.loadingError.message}</div>
+                    <div>Once you have a Riff video meeting,</div>
+                    <div>your Riff stats will display here.</div>
                 </LoadingErrorMessage>
             );
         }

--- a/components/dashboard/DashboardView.jsx
+++ b/components/dashboard/DashboardView.jsx
@@ -44,40 +44,41 @@ const DashboardView = (props) => {
             />
         );
     });
-
     const component = () => {
-      //errored
-      if (props.loadingError.status) {
-          return (
-              <LoadingErrorMessage>
-                  <div>{'Welcome to your Riff Dashboard!'}</div>
-                  <br/>
-                  <div >{props.loadingError.message}</div>
-              </LoadingErrorMessage>
-          );
-      }
-      //loading, until first meeting's stats are loaded (errors have also not loaded yet)
-      else if (props.statsStatus[0] !== 'loaded') {
-          return (
-              <div className="columns has-text-centered is-centered is-vcentered"
-                       style={{minHeight: "80vh", minWidth: "80vw"}}>
-                  <ScaleLoader color={'#8A6A94'}/>
-              </div>
-          );
-      }
-      //meetings
-      else if (props.meetings.length > 0) {
-          return (
-              <div style={{overflowY: 'scroll'}}>
-                  {meetingVisualizations}
-              </div>
-          );
-      }
-      //default
-      else {
-          return false;
-      }
-    }
+
+        //errored
+        if (props.loadingError.status) {
+            return (
+                <LoadingErrorMessage>
+                    <div>Welcome to your Riff Dashboard!</div>
+                    <br/>
+                    <div >{props.loadingError.message}</div>
+                </LoadingErrorMessage>
+            );
+        }
+
+        //loading, until first meeting's stats are loaded (the above loadingError has also not loaded yet)
+        else if (props.statsStatus[0] !== 'loaded') {
+            return (
+                <div className='columns has-text-centered is-centered is-vcentered'
+                         style={{minHeight: '80vh', minWidth: '80vw'}}>
+                    <ScaleLoader color='#8A6A94'/>
+                </div>
+            );
+        }
+
+        //meetings
+        else if (props.meetings.length > 0) {
+            return (
+                <div style={{overflowY: 'scroll'}}>
+                    {meetingVisualizations}
+                </div>
+            );
+        }
+
+        //default
+        return false;
+    };
 
     return (
         <div className='app__content'>

--- a/components/dashboard/DashboardView.jsx
+++ b/components/dashboard/DashboardView.jsx
@@ -3,12 +3,15 @@
 
 /* eslint
     header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" } }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
  */
 
 import React from 'react';
 import styled from 'styled-components';
 import {ScaleLoader} from 'react-spinners';
-import _ from 'underscore';
 
 import {logger} from 'utils/riff';
 
@@ -32,10 +35,10 @@ const LoadingErrorMessage = styled.div.attrs({
 
 const DashboardView = (props) => {
     logger.debug('only loading:', props.numLoadedMeetings, 'Meetings');
-    const meetingVisualizations = _.map(_.first(props.meetings, props.numLoadedMeetings), (m) => {
+    const meetingVisualizations = props.meetings.slice(0, props.numLoadedMeetings).map((m) => {
         return (
             <MeetingViz
-                key={m._id} // eslint-disable-line no-underscore-dangle
+                key={m._id}
                 meeting={m}
                 allMeetings={props.meetings}
                 maybeLoadNextMeeting={props.maybeLoadNextMeeting}
@@ -80,6 +83,7 @@ const DashboardView = (props) => {
         //default
         return false;
     };
+
     return (
         <div className='app__content'>
             {component()}

--- a/components/dashboard/DashboardView.jsx
+++ b/components/dashboard/DashboardView.jsx
@@ -57,7 +57,7 @@ const DashboardView = (props) => {
         }
 
         //loading, until first meeting's stats are loaded (the above loadingError has also not loaded yet)
-        else if (props.statsStatus[0] !== 'loaded') {
+        if (props.statsStatus[0] !== 'loaded') {
             return (
                 <div
                     className='columns has-text-centered is-centered is-vcentered'
@@ -69,7 +69,7 @@ const DashboardView = (props) => {
         }
 
         //meetings
-        else if (props.meetings.length > 0) {
+        if (props.meetings.length > 0) {
             return (
                 <div style={{overflowY: 'scroll'}}>
                     {meetingVisualizations}

--- a/components/dashboard/DashboardView.jsx
+++ b/components/dashboard/DashboardView.jsx
@@ -44,15 +44,14 @@ const DashboardView = (props) => {
         );
     });
     const component = () => {
-
         //errored (catch all static message is shown, these errors are all related to having no meetings)
         if (props.loadingError.status) {
             return (
                 <LoadingErrorMessage>
-                    <div>Welcome to your Riff Dashboard!</div>
+                    <div>{'Welcome to your Riff Dashboard!'}</div>
                     <br/>
-                    <div>Once you have a Riff video meeting,</div>
-                    <div>your Riff stats will display here.</div>
+                    <div>{'Once you have a Riff video meeting,'}</div>
+                    <div>{'your Riff stats will display here.'}</div>
                 </LoadingErrorMessage>
             );
         }
@@ -60,8 +59,10 @@ const DashboardView = (props) => {
         //loading, until first meeting's stats are loaded (the above loadingError has also not loaded yet)
         else if (props.statsStatus[0] !== 'loaded') {
             return (
-                <div className='columns has-text-centered is-centered is-vcentered'
-                         style={{minHeight: '80vh', minWidth: '80vw'}}>
+                <div
+                    className='columns has-text-centered is-centered is-vcentered'
+                    style={{minHeight: '80vh', minWidth: '80vw'}}
+                >
                     <ScaleLoader color='#8A6A94'/>
                 </div>
             );
@@ -79,7 +80,6 @@ const DashboardView = (props) => {
         //default
         return false;
     };
-
     return (
         <div className='app__content'>
             {component()}

--- a/reducers/views/dashboard.js
+++ b/reducers/views/dashboard.js
@@ -103,9 +103,9 @@ const dashboard = (state = initialState, action) => {
     case DashboardActionTypes.DASHBOARD_LOADING_ERROR:
         return {
             ...state,
-            error: {
-                ...action.message,
-                ...action.status,
+            loadingError: {
+                message:action.message,
+                status:action.status,
             },
         };
 

--- a/reducers/views/dashboard.js
+++ b/reducers/views/dashboard.js
@@ -104,8 +104,8 @@ const dashboard = (state = initialState, action) => {
         return {
             ...state,
             loadingError: {
-                message:action.message,
-                status:action.status,
+                message: action.message,
+                status: action.status,
             },
         };
 
@@ -116,6 +116,10 @@ const dashboard = (state = initialState, action) => {
                                    state.statsStatus,
                                    action.meetingId,
                                    action.status),
+            loadingError: {
+                status: false,
+                message: '',
+            },
         };
     case DashboardActionTypes.DASHBOARD_FETCH_MEETING_UTTERANCES:
         return updateLoadingStatus({


### PR DESCRIPTION
#### Summary
Minor revamp of DashboardView page. 

When clicking Riff Stats, now it initially shows the loader..once the first meeting's stats has loaded, it shows the page, while the other meeting's stats continue to load. If the user hasn't had any meetings that are sufficient for stats yet, they will be shown a relevant message at this time.

Please read commit messages for more info on each step.

#### Ticket Link
https://trello.com/c/425ZpoyI/262-initial-dashboard-message-flashes-when-you-click-the-dashboard-channel

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes
