### PR TITLE
Fix/timeline name labels

### DIFF
--- a/components/dashboard/components/TimelineChart.jsx
+++ b/components/dashboard/components/TimelineChart.jsx
@@ -30,11 +30,11 @@ const drawGantt = (props) => {
     //is 720px (width of parent, <MeetingViz/>)
     //what seemed to work was truncating the name to 13 characters, plus an ellipsis
 
-    const truncateBreakPoint = 720;
-    const minTruncateLength = 13;
-    const maxTruncateLength = 18; //even though signup limits to 22 char, this is a safety net, 22 char can break
+    const maxNarrowWidth = 720;
+    const maxNameLenNarrow = 13;
+    const maxNameLenWide = 18; //even though signup limits to 22 char, this is a safety net, 22 char can break
 
-    const truncateLength = props.width < truncateBreakPoint ? minTruncateLength : maxTruncateLength;
+    const truncateLength = props.width < maxNarrowWidth ? maxNameLenNarrow : maxNameLenWide;
     const participantNames = participants.map((p) => textTruncate(p.name, truncateLength));
 
     // create the participant map of id to name and color, filter out and

--- a/components/dashboard/components/TimelineChart.jsx
+++ b/components/dashboard/components/TimelineChart.jsx
@@ -11,7 +11,7 @@ import React from 'react';
 import {ScaleLoader} from 'react-spinners';
 import lifecycle from 'react-pure-lifecycle';
 
-import {logger, PeerColors} from 'utils/riff';
+import {logger, PeerColors, textTruncate} from 'utils/riff';
 
 import {Gantt} from './gantt';
 import ChartCard from './ChartCard';
@@ -24,7 +24,7 @@ const drawGantt = (props) => {
     // create map of id: name
     // local user will always be first.
     logger.debug('sorted participants:', participants);
-    const participantNames = participants.map((p) => p.name);
+    const participantNames = participants.map((p) => textTruncate(p.name,20));
 
     // create the participant map of id to name and color, filter out and
     // set the current user first, then add the other participants

--- a/components/dashboard/components/TimelineChart.jsx
+++ b/components/dashboard/components/TimelineChart.jsx
@@ -24,7 +24,17 @@ const drawGantt = (props) => {
     // create map of id: name
     // local user will always be first.
     logger.debug('sorted participants:', participants);
-    const truncateLength = props.width < 720 ? 13 : 18;
+
+    //since the decision was made to limit the length of the name on the y-axis if overflowing,
+    //the breakpoint at which the name should be truncated,
+    //is 720px (width of parent, <MeetingViz/>)
+    //what seemed to work was truncating the name to 13 characters, plus an ellipsis
+
+    const truncateBreakPoint = 720;
+    const minTruncateLength = 13;
+    const maxTruncateLength = 18; //even though signup limits to 22 char, this is a safety net, 22 char can break
+
+    const truncateLength = props.width < truncateBreakPoint ? minTruncateLength : maxTruncateLength;
     const participantNames = participants.map((p) => textTruncate(p.name, truncateLength));
 
     // create the participant map of id to name and color, filter out and

--- a/components/dashboard/components/TimelineChart.jsx
+++ b/components/dashboard/components/TimelineChart.jsx
@@ -24,7 +24,8 @@ const drawGantt = (props) => {
     // create map of id: name
     // local user will always be first.
     logger.debug('sorted participants:', participants);
-    const participantNames = participants.map((p) => textTruncate(p.name, 20));
+    const truncateLength = props.width < 720 ? 15 : 20;
+    const participantNames = participants.map((p) => textTruncate(p.name, truncateLength));
 
     // create the participant map of id to name and color, filter out and
     // set the current user first, then add the other participants

--- a/components/dashboard/components/TimelineChart.jsx
+++ b/components/dashboard/components/TimelineChart.jsx
@@ -24,7 +24,7 @@ const drawGantt = (props) => {
     // create map of id: name
     // local user will always be first.
     logger.debug('sorted participants:', participants);
-    const truncateLength = props.width < 720 ? 15 : 20;
+    const truncateLength = props.width < 720 ? 13 : 18;
     const participantNames = participants.map((p) => textTruncate(p.name, truncateLength));
 
     // create the participant map of id to name and color, filter out and

--- a/components/dashboard/components/TimelineChart.jsx
+++ b/components/dashboard/components/TimelineChart.jsx
@@ -24,7 +24,7 @@ const drawGantt = (props) => {
     // create map of id: name
     // local user will always be first.
     logger.debug('sorted participants:', participants);
-    const participantNames = participants.map((p) => textTruncate(p.name,20));
+    const participantNames = participants.map((p) => textTruncate(p.name, 20));
 
     // create the participant map of id to name and color, filter out and
     // set the current user first, then add the other participants

--- a/components/dashboard/components/gantt.js
+++ b/components/dashboard/components/gantt.js
@@ -199,6 +199,7 @@ export class Gantt {
             .attr('class', 'chart')
             .attr('width', containerSize.width)
             .attr('height', containerSize.height)
+            .style('overflow', 'visible')
             .append('g')
             .attr('class', 'gantt-chart')
             .attr('role', 'figure')

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -219,14 +219,16 @@ export const PeerColors = [
  * an ending to tag onto the end of the string can be passed, by default an ellipsis(...) is applied
  */
 export function textTruncate(string, maxLength, ending) {
-    if (maxLength == null) {
-        maxLength = 100;
+    let maxLengthFinal = maxLength;
+    if (maxLengthFinal == null) {
+        maxLengthFinal = 100;
     }
-    if (ending == null) {
-        ending = '...';
+    let endingFinal = ending;
+    if (endingFinal == null) {
+        endingFinal = '...';
     }
-    if (string.length > maxLength) {
-        return string.substring(0, maxLength - ending.length) + ending;
+    if (string.length > maxLengthFinal) {
+        return string.substring(0, maxLengthFinal - endingFinal.length) + endingFinal;
     }
     return string;
-};
+}

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -212,3 +212,21 @@ export const PeerColors = [
     Colors.darkfern,
     Colors.aquamarine,
 ];
+
+/**
+ * returns a truncated string, with a maximum character count of maxLength
+ * if no maxLength passed, 100 is used by default
+ * an ending to tag onto the end of the string can be passed, by default an ellipsis(...) is applied
+ */
+export function textTruncate(string, maxLength, ending) {
+    if (maxLength == null) {
+        maxLength = 100;
+    }
+    if (ending == null) {
+        ending = '...';
+    }
+    if (string.length > maxLength) {
+        return string.substring(0, maxLength - ending.length) + ending;
+    }
+    return string;
+};

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -225,7 +225,7 @@ export function textTruncate(string, maxLength, ending) {
     }
     let endingFinal = ending;
     if (endingFinal == null) {
-        endingFinal = '...';
+        endingFinal = '\u2026';
     }
     if (string.length > maxLengthFinal) {
         return string.substring(0, maxLengthFinal - endingFinal.length) + endingFinal;

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -214,21 +214,24 @@ export const PeerColors = [
 ];
 
 /**
- * returns a truncated string, with a maximum character count of maxLength
- * if no maxLength passed, 100 is used by default
- * an ending to tag onto the end of the string can be passed, by default an ellipsis(...) is applied
+ * Limit the given string to the specifed number of characters.
+ * If the string has more characters than the max allowed
+ * a new string will be returned which is exactly max characters long
+ * consisting of a suffix of an ellipsis character (U+2026) OR the given
+ * missing character string, and the 1st characters from the given
+ * string to make the returned sting have the max length.
+ *
+ * @param {string} s - The string whose length should not exceed maxLen
+ * @param {number} maxLen - The maximum length of the returned string. default: 100
+ * @param {string} missingCharSuffix - The suffix to replace the truncated
+ *      end of the returned string with. default: ellipsis character
+ *
+ * @returns a string with a maximum of maxLen characters
  */
-export function textTruncate(string, maxLength, ending) {
-    let maxLengthFinal = maxLength;
-    if (maxLengthFinal == null) {
-        maxLengthFinal = 100;
+export function textTruncate(s, maxLen = 100, missingCharSuffix = '\u2026') {
+    if (s.length <= maxLen) {
+        return s;
     }
-    let endingFinal = ending;
-    if (endingFinal == null) {
-        endingFinal = '\u2026';
-    }
-    if (string.length > maxLengthFinal) {
-        return string.substring(0, maxLengthFinal - endingFinal.length) + endingFinal;
-    }
-    return string;
+
+    return s.slice(0, maxLen - missingCharSuffix.length) + missingCharSuffix;
 }


### PR DESCRIPTION
#### Summary
Allowed visible overflow on the charts, which revealed the previously cut-off longer names.
To further address the issue of name length, I added a function to truncate strings. I used this to set a max length for names to 17 characters, with a 3 character ellipsis applied.

#### Ticket Link
https://trello.com/c/tVrb2NB8/268-timeline-graph-truncates-name-labels

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes