### PR TITLE
Made the dashboard adjust its width to accommodate the side panel bei…

### DIFF
--- a/components/dashboard/components/MeetingViz.jsx
+++ b/components/dashboard/components/MeetingViz.jsx
@@ -18,12 +18,14 @@ import PropTypes from 'prop-types';
 import {
     loadMeetingData,
 } from '../../../actions/views/dashboard';
+
 import {logger} from '../../../utils/riff';
+
+import {getIsRhsOpen} from 'selectors/rhs';
 
 import TurnChart from './TurnChart';
 import InfluenceChart from './InfluenceChart';
 import TimelineChart from './TimelineChart';
-import {getIsRhsOpen} from 'selectors/rhs';
 const SpaceBetweeen = styled.div.attrs({
     className: 'space-between',
 })`
@@ -175,17 +177,20 @@ class MeetingViz extends React.Component {
             <Waypoint onEnter={this.loadThisAndMaybeMore}>
                 <div>
                     <Header {...this.props}/>
-                    <div className="columns is-centered" style={{marginLeft: '2rem', marginRight: '1rem'}}>
-                        <div className="column" style={{paddingBottom: '0px'}}>
+                    <div className='columns is-centered'
+                        style={{marginLeft: '2rem', marginRight: '1rem'}}
+                    >
+                        <div className='column'
+                            style={{paddingBottom: '0px'}}>
                             <div className={`columns is-centered is-hidden-touch ${this.props.rhsOpen ? 'is-hidden' : ''}`}>
-                                <div className="column is-centered has-text-centered">
+                                <div className='column is-centered has-text-centered'>
                                     <TurnChart
                                         processedUtterances={this.props.processedUtterances}
                                         loaded={this.props.loaded}
                                         participantId={this.props.user.id}
                                     />
                                 </div>
-                                <div className="column is-centered" >
+                                <div className='column is-centered' >
                                     <InfluenceChart
                                         influenceType={'mine'}
                                         processedInfluence={this.props.influenceData}
@@ -193,7 +198,7 @@ class MeetingViz extends React.Component {
                                         participantId={this.props.user.id}
                                     />
                                 </div>
-                                <div className="column is-centered" >
+                                <div className='column is-centered' >
                                     <InfluenceChart
                                         influenceType={'theirs'}
                                         processedInfluence={this.props.influenceData}
@@ -211,9 +216,9 @@ class MeetingViz extends React.Component {
                                     />
                                 </div>
 
-                                <div className="column">
-                                    <div className="columns is-multiline is-hidden-mobile">
-                                        <div className="column is-half has-text-centered is-centered">
+                                <div className='column'>
+                                    <div className='columns is-multiline is-hidden-mobile'>
+                                        <div className='column is-half has-text-centered is-centered'>
                                             <InfluenceChart
                                                 influenceType={'mine'}
                                                 processedInfluence={this.props.influenceData}
@@ -221,7 +226,7 @@ class MeetingViz extends React.Component {
                                                 participantId={this.props.user.id}
                                             />
                                         </div>
-                                        <div className="column is-half has-text-centered is-centered">
+                                        <div className='column is-half has-text-centered is-centered'>
                                             <InfluenceChart
                                                 influenceType={'theirs'}
                                                 processedInfluence={this.props.influenceData}
@@ -230,8 +235,8 @@ class MeetingViz extends React.Component {
                                             />
                                         </div>
                                     </div>
-                                    <div className="columns is-multiline is-hidden-tablet">
-                                        <div className="column has-text-centered is-centered">
+                                    <div className='columns is-multiline is-hidden-tablet'>
+                                        <div className='column has-text-centered is-centered'>
                                             <InfluenceChart
                                                 influenceType={'mine'}
                                                 processedInfluence={this.props.influenceData}
@@ -239,7 +244,7 @@ class MeetingViz extends React.Component {
                                                 participantId={this.props.user.id}
                                             />
                                         </div>
-                                        <div className="column has-text-centered is-centered">
+                                        <div className='column has-text-centered is-centered'>
                                             <InfluenceChart
                                                 influenceType={'theirs'}
                                                 processedInfluence={this.props.influenceData}
@@ -251,9 +256,11 @@ class MeetingViz extends React.Component {
                                 </div>
                             </div>
 
-                            <div className="section" style={{padding: '0px'}}>
-                                <div className="columns is-centered">
-                                    <div className="column is-centered has-text-centered">
+                            <div className='section'
+                                style={{padding: '0px'}}
+                            >
+                                <div className='columns is-centered'>
+                                    <div className='column is-centered has-text-centered'>
                                         <TimelineChart
                                             processedTimeline={this.props.timelineData}
                                             loaded={this.props.loaded}

--- a/components/dashboard/components/MeetingViz.jsx
+++ b/components/dashboard/components/MeetingViz.jsx
@@ -23,7 +23,7 @@ import {logger} from '../../../utils/riff';
 import TurnChart from './TurnChart';
 import InfluenceChart from './InfluenceChart';
 import TimelineChart from './TimelineChart';
-
+import {getIsRhsOpen} from 'selectors/rhs';
 const SpaceBetweeen = styled.div.attrs({
     className: 'space-between',
 })`
@@ -64,6 +64,7 @@ const mapStateToProps = (state, ownProps) => {
         timelineData: dashboard.timelineData[idx],
         selectedMeetingDuration: formatMeetingDuration(dashboard.meetings[idx]),
         loaded: dashboard.statsStatus[idx] === 'loaded',
+        rhsOpen: getIsRhsOpen(state),
     };
 };
 
@@ -176,7 +177,7 @@ class MeetingViz extends React.Component {
                     <Header {...this.props}/>
                     <div className="columns is-centered" style={{marginLeft: '2rem', marginRight: '1rem'}}>
                         <div className="column" style={{paddingBottom: '0px'}}>
-                            <div className="columns is-centered is-hidden-touch">
+                            <div className={`columns is-centered is-hidden-touch ${this.props.rhsOpen ? 'is-hidden' : ''}`}>
                                 <div className="column is-centered has-text-centered">
                                     <TurnChart
                                         processedUtterances={this.props.processedUtterances}
@@ -201,8 +202,8 @@ class MeetingViz extends React.Component {
                                     />
                                 </div>
                             </div>
-                            <div className="columns is-hidden-desktop is-multiline is-centered">
-                                <div className="column has-text-centered is-centered">
+                            <div className={`columns is-multiline is-centered ${this.props.rhsOpen ? '' : 'is-hidden-desktop'}`}>
+                                <div className={`column has-text-centered is-centered is-full-tablet ${this.props.rhsOpen ? 'is-full' : ''}`}>
                                     <TurnChart
                                         processedUtterances={this.props.processedUtterances}
                                         loaded={this.props.loaded}

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1599,24 +1599,6 @@ export const Constants = {
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
     TRIPLE_BACK_TICKS: /```/g,
     SYSTEM_BRAND_NAME: 'Riff Edu',
-    SCREEN_BREAKPOINTS: {
-        desktop: {
-            min: 1088,
-            max: 10000,
-        },
-        touch: {
-            min: 0,
-            max: 1087,
-        },
-        tablet: {
-            min: 769,
-            max: 1087,
-        },
-        mobile: {
-            min: 0,
-            max: 768,
-        },
-    },
 };
 
 t('suggestion.mention.channels');

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1599,6 +1599,24 @@ export const Constants = {
         'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
     TRIPLE_BACK_TICKS: /```/g,
     SYSTEM_BRAND_NAME: 'Riff Edu',
+    SCREEN_BREAKPOINTS: {
+      desktop: {
+        min:1088,
+        max:10000
+      },
+      touch: {
+        min:0,
+        max:1087
+      },
+      tablet: {
+        min:769,
+        max:1087
+      },
+      mobile: {
+        min:0,
+        max:768
+      },
+    },
 };
 
 t('suggestion.mention.channels');

--- a/utils/constants.jsx
+++ b/utils/constants.jsx
@@ -1600,22 +1600,22 @@ export const Constants = {
     TRIPLE_BACK_TICKS: /```/g,
     SYSTEM_BRAND_NAME: 'Riff Edu',
     SCREEN_BREAKPOINTS: {
-      desktop: {
-        min:1088,
-        max:10000
-      },
-      touch: {
-        min:0,
-        max:1087
-      },
-      tablet: {
-        min:769,
-        max:1087
-      },
-      mobile: {
-        min:0,
-        max:768
-      },
+        desktop: {
+            min: 1088,
+            max: 10000,
+        },
+        touch: {
+            min: 0,
+            max: 1087,
+        },
+        tablet: {
+            min: 769,
+            max: 1087,
+        },
+        mobile: {
+            min: 0,
+            max: 768,
+        },
     },
 };
 


### PR DESCRIPTION
#### Summary
To accommodate the right side panel being open when on the Dashboard route, I added some CSS classes to some elements to essentially force the layout into touch mode.

This was a little tricky and took a little bit of tinkering, since this page uses CSS classes defined in node_modules/bulma to determine which content is displayed. Desktop content is conditionally displayed with 'is-hidden-touch', and stacked mobile content is displayed with 'is-hidden-desktop'. This happens at 1087px screen width. In this PR, if the sidebar is open, the desktop content is given the class 'is-hidden' instead of the condition 'is-hidden-touch'. The 'touch' content is then displayed by not giving it the 'is-hidden-desktop'. When the sidebar is closed, these classes are removed, and the charts adjust.

Explicitly setting the container of the pie chart to full width on tablet (even without sidebar open) seemed to make sense as well, since it looked a little broken locally for meetings that didn't have any stats.

I also added an entry to constants which defines the screen breakpoints. I was going to use it, but I ended up taking a different path. It may be useful in the future, but I can remove it if you don't agree.

#### Ticket Link
https://trello.com/c/P23zhrQe/258-reformat-metrics-in-dashboard-to-adjust-to-screen-real-estate

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes
