### PR TITLE
Fix/voice chat icon aria

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -443,7 +443,10 @@ export default class ChannelHeader extends React.Component {
                                 id='webrtc-btn'
                                 className={'webrtc__button hidden-xs ' + circleClass}
                             >
-                                <span className='icon icon__members'><MaterialIcon icon='voice_chat'/></span>
+                                <span className='icon icon__members'
+                                    aria-label='Start a voice chat'>
+                                    <MaterialIcon icon='voice_chat'/>
+                                </span>
                             </div>
                         </button>
                     </PopoverStickOnHover>

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -415,8 +415,8 @@ export default class ChannelHeader extends React.Component {
                 style={{cursor: this.webRtcDisabled() ? 'default' : 'pointer'}}
             >
                 <Link
-                    target="_blank"
-                    id="videochat"
+                    target='_blank'
+                    id='videochat'
                     disabled={this.webRtcDisabled()}
                     to={this.props.webRtcLink.pathname}
                     onClick={() => {
@@ -432,7 +432,7 @@ export default class ChannelHeader extends React.Component {
                 >
                     <PopoverStickOnHover
                         component={webrtcTooltip}
-                        placement="bottom"
+                        placement='bottom'
                         delay={Constants.WEBRTC_TIME_DELAY}
                     >
                         <button
@@ -443,8 +443,10 @@ export default class ChannelHeader extends React.Component {
                                 id='webrtc-btn'
                                 className={'webrtc__button hidden-xs ' + circleClass}
                             >
-                                <span className='icon icon__members'
-                                    aria-label='Start a voice chat'>
+                                <span
+                                    className='icon icon__members'
+                                    aria-label='Start a voice chat'
+                                >
                                     <MaterialIcon icon='voice_chat'/>
                                 </span>
                             </div>


### PR DESCRIPTION
#### Summary
Added aria-label to 'start a voice/video chat' icon.

#### Ticket Link
https://trello.com/c/k2gImF5t/280-a11y-voice-chat-icon-has-no-text-alternative

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)