### PR TITLE
Removed condition to show loader overlay, when Dashboard initially loads

### DIFF
--- a/components/dashboard/DashboardView.jsx
+++ b/components/dashboard/DashboardView.jsx
@@ -59,18 +59,6 @@ const DashboardView = (props) => {
             );
         }
 
-        //loading, until first meeting's stats are loaded (the above loadingError has also not loaded yet)
-        if (props.statsStatus[0] !== 'loaded') {
-            return (
-                <div
-                    className='columns has-text-centered is-centered is-vcentered'
-                    style={{minHeight: '80vh', minWidth: '80vw'}}
-                >
-                    <ScaleLoader color='#8A6A94'/>
-                </div>
-            );
-        }
-
         //meetings
         if (props.meetings.length > 0) {
             return (


### PR DESCRIPTION
#### Summary
The code to display the overlay loader before the recent dashboard revamp(PR below), was dormant I believe. And this allowed things to work.

https://github.com/rifflearning/mattermost-webapp/pull/67

The following line of code, determined when to show the loader:
`props.statsStatus === 'loading'`
statsStatus is an array of strings, and I think this will always return false.

#### Ticket Link
https://trello.com/c/v96zDVOz/288-timeline-bug
