### PR TITLE
Fixed videoChat icon clickable bug

### DIFF
--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -375,6 +375,19 @@ export default class ChannelHeader extends React.Component {
                 this.props.channelStats.member_count > 7);
     }
 
+    videoChatClicked = (e) => {
+        if (this.webRtcDisabled()) {
+            e.preventDefault();
+        } else {
+            this.props.actions.sendWebRtcMessage(
+                this.props.channel.id,
+                this.props.currentUser.id,
+                this.props.webRtcLink.href,
+                this.props.currentTeam.name
+            );
+        }
+    }
+
     renderWebRtc = (circleClass) => {
         let tooltipContent = null;
         if (!this.props.channelStats) {
@@ -417,18 +430,8 @@ export default class ChannelHeader extends React.Component {
                 <Link
                     target='_blank'
                     id='videochat'
-                    disabled={this.webRtcDisabled()}
-                    to={this.props.webRtcLink.pathname}
-                    onClick={() => {
-                        if (!this.webRtcDisabled()) {
-                            this.props.actions.sendWebRtcMessage(
-                                this.props.channel.id,
-                                this.props.currentUser.id,
-                                this.props.webRtcLink.href,
-                                this.props.currentTeam.name
-                            );
-                        }
-                    }}
+                    to={this.webRtcDisabled() ? false : this.props.webRtcLink.pathname}
+                    onClick={(e) => this.videoChatClicked(e)}
                 >
                     <PopoverStickOnHover
                         component={webrtcTooltip}


### PR DESCRIPTION
#### Summary
Removed 'disabled' attribute from <Link />, as this does nothing

Conditionally pass false (if webrtc is disabled) to the 'to' attribute, which makes the <a> tag have an href of '/', which will take you to the current page/go nowhere

Pulled the onclick into a function called videoChatClicked(), and called e.preventDefault() if webrtc is disabled

#### Ticket Link
https://trello.com/c/xHyP0n90/242-starting-a-meeting-in-a-channel-with-7-people-still-brings-you-to-the-video-chat-page-but-doesnt-invite-anyone-else-to-the-meeti

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)