### PR TITLE
switch to using a specific commit from the rifflearning SimpleWebRTC cloned repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1161,8 +1161,8 @@
       "dev": true
     },
     "attachmediastream": {
-      "version": "github:jordanreedie/attachMediaStream#889613872dae1a46eacade0f07e5e0c8b637e848",
-      "from": "github:jordanreedie/attachMediaStream#master"
+      "version": "github:rifflearning/attachMediaStream#889613872dae1a46eacade0f07e5e0c8b637e848",
+      "from": "github:rifflearning/attachMediaStream#889613872dae1a46eacade0f07e5e0c8b637e848"
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -10215,8 +10215,8 @@
       }
     },
     "localmedia": {
-      "version": "github:jordanreedie/localmedia#62adc5be5e1bbaac5fa7b2e8ebfaf0a6bacffa2f",
-      "from": "github:jordanreedie/localmedia#feature/update-get-screen",
+      "version": "github:rifflearning/localmedia#62adc5be5e1bbaac5fa7b2e8ebfaf0a6bacffa2f",
+      "from": "github:rifflearning/localmedia#62adc5be5e1bbaac5fa7b2e8ebfaf0a6bacffa2f",
       "requires": {
         "hark": "^1.0.0",
         "mockconsole": "0.0.x",
@@ -15283,12 +15283,12 @@
       "dev": true
     },
     "simplewebrtc": {
-      "version": "github:jordanreedie/SimpleWebRTC#1e11df8f0f58afbaef73da877d15013519555403",
-      "from": "github:jordanreedie/SimpleWebRTC#feature/screen-sharing",
+      "version": "github:rifflearning/SimpleWebRTC#25616eb081cbcca50ae2166fad9caf2c58fd0fa2",
+      "from": "github:rifflearning/SimpleWebRTC#25616eb081cbcca50ae2166fad9caf2c58fd0fa2",
       "requires": {
-        "attachmediastream": "github:jordanreedie/attachMediaStream#master",
+        "attachmediastream": "github:rifflearning/attachMediaStream#889613872dae1a46eacade0f07e5e0c8b637e848",
         "filetransfer": "^2.0.4",
-        "localmedia": "github:jordanreedie/localmedia#feature/update-get-screen",
+        "localmedia": "github:rifflearning/localmedia#62adc5be5e1bbaac5fa7b2e8ebfaf0a6bacffa2f",
         "mockconsole": "0.0.1",
         "rtcpeerconnection": "^8.0.0",
         "socket.io-client": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "redux-persist-transform-filter": "0.0.18",
     "reselect": "3.0.1",
     "sibilant-webaudio": "github:rifflearning/sibilant#f62e2192ab2ab00f3a3dc4392af9c101329069d7",
-    "simplewebrtc": "github:jordanreedie/SimpleWebRTC#feature/screen-sharing",
+    "simplewebrtc": "github:rifflearning/SimpleWebRTC#25616eb081cbcca50ae2166fad9caf2c58fd0fa2",
     "smoothscroll-polyfill": "0.4.3",
     "socket.io-client": "^2.1.1",
     "styled-components": "^4.0.3",


### PR DESCRIPTION
#### Summary
Update the SimpleWebRTC package version to use the rifflearning/SimpleWebRTC github repo instead of jordanreedie/SimpleWebRTC github repo.

#### Ticket Link
Trello [#253](https://trello.com/c/5GL4tfSW) Merge Jordan's code and repository into Riff repo
