### PR TITLE
Fix undefined TypeError in console when displaying Riff Stats

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ check-style:
     <<: *std_job
     stage: test
     script:
-        - make check-style-ci THRESHOLD=1786
+        - make check-style-ci THRESHOLD=1757
     artifacts:
         when: always
         paths:

--- a/components/dashboard/DashboardView.jsx
+++ b/components/dashboard/DashboardView.jsx
@@ -33,8 +33,8 @@ const LoadingErrorMessage = styled.div.attrs({
 // All dispatches were ripped out re-copy back in once server is working
 
 const DashboardView = (props) => {
-    logger.debug('only loading:', props.numLoadedMeetings, 'Meetings');
-    const meetingVisualizations = props.meetings.slice(0, props.numLoadedMeetings).map((m) => {
+    logger.debug('only loading:', props.numMeetingsToDisplay, 'Meetings');
+    const meetingVisualizations = props.meetings.slice(0, props.numMeetingsToDisplay).map((m) => {
         return (
             <MeetingViz
                 key={m._id}

--- a/components/dashboard/index.js
+++ b/components/dashboard/index.js
@@ -49,7 +49,7 @@ const mapStateToProps = (state) => {
         processedNetwork: riffState.networkData,
         processedTimeline: riffState.timelineData,
         loadingError: riffState.loadingError,
-        numLoadedMeetings: riffState.numLoadedMeetings,
+        numMeetingsToDisplay: riffState.numMeetingsToDisplay,
     };
 };
 
@@ -98,13 +98,13 @@ const mapMergeProps = (stateProps, dispatchProps, ownProps) => {
             stateProps.meetings[0]
         ),
         maybeLoadNextMeeting: (meetingId) => {
-            if (!stateProps.meetings || stateProps.numLoadedMeetings < 1 || stateProps.numLoadedMeetings > stateProps.meetings.length) {
+            if (!stateProps.meetings || stateProps.numMeetingsToDisplay < 1 || stateProps.numMeetingsToDisplay > stateProps.meetings.length) {
                 // I believe this is happening, the question is when and why -mjl
-                // What I've seen now is that the numLoadedMeetings is greater than the number of meetings
+                // What I've seen now is that the numMeetingsToDisplay is greater than the number of meetings
                 // in the meetings array.
-                logger.error(`Dashboard.maybeLoadNextMeeting: meetings is not an array or the # loaded meetings (${stateProps.numLoadedMeetings}) is a problem!`, stateProps.meetings);
+                logger.error(`Dashboard.maybeLoadNextMeeting: meetings is not an array or the # loaded meetings (${stateProps.numMeetingsToDisplay}) is a problem!`, stateProps.meetings);
             }
-            const lastLoadedMeeting = stateProps.meetings[stateProps.numLoadedMeetings - 1];
+            const lastLoadedMeeting = stateProps.meetings[stateProps.numMeetingsToDisplay - 1];
             logger.debug('Dashboard.maybeLoadNextMeeting: lastLoadedMeeting', lastLoadedMeeting);
             if (lastLoadedMeeting._id === meetingId) {
                 logger.debug('Dashboard.maybeLoadNextMeeting: loading more meetings!');

--- a/components/dashboard/index.js
+++ b/components/dashboard/index.js
@@ -98,10 +98,16 @@ const mapMergeProps = (stateProps, dispatchProps, ownProps) => {
             stateProps.meetings[0]
         ),
         maybeLoadNextMeeting: (meetingId) => {
+            if (!stateProps.meetings || stateProps.numLoadedMeetings < 1 || stateProps.numLoadedMeetings > stateProps.meetings.length) {
+                // I believe this is happening, the question is when and why -mjl
+                // What I've seen now is that the numLoadedMeetings is greater than the number of meetings
+                // in the meetings array.
+                logger.error(`Dashboard.maybeLoadNextMeeting: meetings is not an array or the # loaded meetings (${stateProps.numLoadedMeetings}) is a problem!`, stateProps.meetings);
+            }
             const lastLoadedMeeting = stateProps.meetings[stateProps.numLoadedMeetings - 1];
-            logger.debug('Maybe loading more meetings', lastLoadedMeeting);
+            logger.debug('Dashboard.maybeLoadNextMeeting: lastLoadedMeeting', lastLoadedMeeting);
             if (lastLoadedMeeting._id === meetingId) {
-                logger.debug('loading more meetings!');
+                logger.debug('Dashboard.maybeLoadNextMeeting: loading more meetings!');
                 dispatchProps.loadMoreMeetings();
             }
         },

--- a/components/dashboard/index.js
+++ b/components/dashboard/index.js
@@ -30,7 +30,7 @@ import * as UserAgent from 'utils/user_agent.jsx';
 import DashboardView from './DashboardView';
 
 const mapStateToProps = (state) => {
-    logger.debug('dashboard state:', state);
+    logger.debug('Dashboard.mapStateToProps: state:', state);
     const {lti, dashboard, riff} = state.views;
     const riffState = {...lti, ...dashboard, ...riff};
     return {
@@ -71,7 +71,7 @@ const mapDispatchToProps = (dispatch) => ({
         dispatch(loadMeetingData(uid, meeting._id));
     },
     authenticateRiff: () => {
-        logger.debug('attempt data-server auth');
+        logger.debug('Dashboard.authenticateRiff: attempt data-server auth');
         dispatch(RiffServerActionCreators.attemptRiffAuthenticate());
     },
 });
@@ -89,7 +89,7 @@ const formatMeetingDuration = (meeting) => {
 };
 
 const mapMergeProps = (stateProps, dispatchProps, ownProps) => {
-    logger.debug('dashboard user:', stateProps.user);
+    logger.debug('Dashboard.mapMergeProps: user:', stateProps.user);
     return {
         ...stateProps,
         ...dispatchProps,
@@ -97,17 +97,20 @@ const mapMergeProps = (stateProps, dispatchProps, ownProps) => {
         selectedMeetingDuration: formatMeetingDuration(
             stateProps.meetings[0]
         ),
+
+        // TODO: Load is the wrong terminalogy here, and maybe also in more of these properties as well.
+        //       Consider renaming this to maybeDisplayNextMeeting -mjl 2019-04-26
         maybeLoadNextMeeting: (meetingId) => {
-            if (!stateProps.meetings || stateProps.numMeetingsToDisplay < 1 || stateProps.numMeetingsToDisplay > stateProps.meetings.length) {
-                // I believe this is happening, the question is when and why -mjl
-                // What I've seen now is that the numMeetingsToDisplay is greater than the number of meetings
-                // in the meetings array.
-                logger.error(`Dashboard.maybeLoadNextMeeting: meetings is not an array or the # loaded meetings (${stateProps.numMeetingsToDisplay}) is a problem!`, stateProps.meetings);
+            // if there are undisplayed meetings AND the last displayed meeting is the specified one
+            // then load (well display) more meetings (ie the next one).
+            if (stateProps.numMeetingsToDisplay >= stateProps.meetings.length) {
+                return;
             }
-            const lastLoadedMeeting = stateProps.meetings[stateProps.numMeetingsToDisplay - 1];
-            logger.debug('Dashboard.maybeLoadNextMeeting: lastLoadedMeeting', lastLoadedMeeting);
-            if (lastLoadedMeeting._id === meetingId) {
-                logger.debug('Dashboard.maybeLoadNextMeeting: loading more meetings!');
+
+            const lastDisplayedMeeting = stateProps.meetings[stateProps.numMeetingsToDisplay - 1];
+            logger.debug('Dashboard.maybeLoadNextMeeting: lastDisplayedMeeting', lastDisplayedMeeting);
+            if (lastDisplayedMeeting._id === meetingId) {
+                logger.debug(`Dashboard.maybeLoadNextMeeting: displaying more meetings (${stateProps.numMeetingsToDisplay})!`);
                 dispatchProps.loadMoreMeetings();
             }
         },
@@ -134,7 +137,7 @@ const componentDidMount = (props) => {
 };
 
 const componentWillMount = (props) => {
-    logger.debug('dashboard user:', props.user);
+    logger.debug('Dashboard.componentWillMount: user:', props.user);
     if (!props.riff.authToken) {
         props.authenticateRiff();
     }

--- a/reducers/views/dashboard.js
+++ b/reducers/views/dashboard.js
@@ -3,7 +3,8 @@
 
 /* eslint
     header/header: "off",
-    indent: ["error", 4, { "CallExpression": { "arguments": "first" } }]
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" } }],
+    brace-style: ["error", "stroustrup", { "allowSingleLine": true }],
  */
 
 import _ from 'underscore';
@@ -61,6 +62,7 @@ const updateLoadingStatus = (state) => {
     const meetingLoaded = unzipped.map((processedDatasets) => processedDatasets.every((dataset) => Boolean(dataset)));
     logger.debug('meetingLoaded', meetingLoaded);
 
+    // eslint-disable-next-line max-statements-per-line
     const isLoadedArray = meetingLoaded.map((isLoaded) => {return isLoaded ? 'loaded' : 'loading';});
     return {
         ...state,

--- a/reducers/views/dashboard.js
+++ b/reducers/views/dashboard.js
@@ -25,8 +25,8 @@ const initialState = {
     // 'loaded' at idx if utterances, influence, and timeline are all loaded
     statsStatus: [],
 
-    // initial number of meetings to load
-    numLoadedMeetings: 2,
+    // initial number of meetings to display (visualize)
+    numMeetingsToDisplay: 2,
 
     // array holding processed data for each meeting.
     processedUtterances: [],
@@ -77,7 +77,7 @@ const dashboard = (state = initialState, action) => {
     case DashboardActionTypes.DASHBOARD_LOAD_MORE_MEETINGS:
         return {
             ...state,
-            numLoadedMeetings: state.numLoadedMeetings + 1,
+            numMeetingsToDisplay: state.numMeetingsToDisplay + 1,
         };
     case DashboardActionTypes.DASHBOARD_FETCH_MEETINGS: {
         const timeDiff = ((((new Date()).getTime() - new Date(state.lastFetched).getTime()) / 1000) > 5);


### PR DESCRIPTION
#### Summary
Fix the undefined TypeError that sometimes occurs when displaying Riff Stats.

The cause was a misleadingly named state property `numLoadedMeetings`.
The property is actually supposed to be the max number of meeting stats to display
(visualize). It's value can be (and was occasionally) greater than the total number of
meetings (or at least the total number of meetings in the meetings property).

The issue is fixed first by renaming the `numLoadedMeetings` property to `numMeetingsToDisplay` and then by checking that the number of meetings in the array is greater than that property
before referencing a member of the array that doesn't exist.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
