### PR TITLE
mediator a11y data tables

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ check-style:
     <<: *std_job
     stage: test
     script:
-        - make check-style-ci THRESHOLD=1717
+        - make check-style-ci THRESHOLD=1593
     artifacts:
         when: always
         paths:

--- a/components/webrtc_view_bulma/MeetingMediator.jsx
+++ b/components/webrtc_view_bulma/MeetingMediator.jsx
@@ -1,12 +1,23 @@
-import util from 'util';
-import React, { Component } from "react";
-import { withRouter } from "react-router-dom";
-import { connect } from 'react-redux';
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" } }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+ */
+
+import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
+
+import {app, logger} from 'utils/riff';
+import ChartTable from 'components/dashboard/components/ChartTable';
+
 import Mediator from './charts';
 import startRiffListener from './RiffListener';
-import { app, socket} from "../../utils/riff";
-import ChartTable from '../dashboard/components/ChartTable'
 
 const MMContainer = styled.div.attrs({
 })`
@@ -18,12 +29,21 @@ const MMContainer = styled.div.attrs({
     overflow: hidden;
 `;
 
+class MeetingMediator extends React.Component {
+    static propTypes = {
+        user: PropTypes.shape({
+            id: PropTypes.string,
+            username: PropTypes.string,
+            nickname: PropTypes.string,
+        }).isRequired,
+        riff: PropTypes.object.isRequired,
+        webRtcPeers: PropTypes.arrayOf(PropTypes.object).isRequired,
+    };
 
-class MeetingMediator extends Component {
     constructor(props) {
         super(props);
         this.state = {
-            tableRows: []
+            tableRows: [],
         };
         this.namesById = this.getNamesById();
         this.updateAccessibleTable = this.updateAccessibleTable.bind(this);
@@ -31,8 +51,8 @@ class MeetingMediator extends Component {
 
     componentDidUpdate(prevProps) {
         //TODO: props.riff here has getters and setters and not values....????
-        console.log("updating with participants:", this.props.riff.participants);
-        let riffCopy = Object.assign({}, this.props.riff);
+        logger.debug('MeetingMediator.componentDidUpdate: updating with participants:', this.props.riff.participants);
+        const riffCopy = Object.assign({}, this.props.riff);
 
         if (prevProps.webRtcPeers !== this.props.webRtcPeers ||
             prevProps.user.id !== this.props.user.id ||
@@ -47,13 +67,13 @@ class MeetingMediator extends Component {
     }
 
     componentDidMount() {
-        console.log("MM props:", this.props);
+        logger.debug('MeetingMediator.componentDidMount: MM props:', this.props);
         startRiffListener();
         this.startMM();
     }
 
     getNamesById() {
-        let namesById = this.props.webRtcPeers.reduce((memo, p) => {
+        const namesById = this.props.webRtcPeers.reduce((memo, p) => {
             const data = p.nick.split('|');
             memo[data[0]] = data[1];
             return memo;
@@ -64,17 +84,17 @@ class MeetingMediator extends Component {
 
     updateAccessibleTable(data) {
         this.setState({
-            tableRows: data.turns.map(turn => [
+            tableRows: data.turns.map((turn) => [
                 this.namesById[turn.participant],
-                [`${Math.round(turn.turns * 100)}%`]
-            ])
+                [`${Math.round(turn.turns * 100)}%`],
+            ]),
         });
     }
 
     startMM() {
         // use ... spread syntax to try to copy instead of
         // passing our state/props by reference.
-        let mediatorProps = Object.assign({}, this.props);
+        const mediatorProps = Object.assign({}, this.props);
         this.mm = new Mediator(
             app,
             (mediatorProps.riff.participants || []),
@@ -91,8 +111,7 @@ class MeetingMediator extends Component {
     render() {
         return (
             <React.Fragment>
-                <MMContainer id = "meeting-mediator">
-                </MMContainer>
+                <MMContainer id='meeting-mediator'/>
                 {this.state.tableRows.length ? (
                     <ChartTable
                         cols={['Participant', 'Amount of Speaking']}

--- a/components/webrtc_view_bulma/MeetingMediator.jsx
+++ b/components/webrtc_view_bulma/MeetingMediator.jsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import Mediator from './charts';
 import startRiffListener from './RiffListener';
 import { app, socket} from "../../utils/riff";
+import ChartTable from '../dashboard/components/ChartTable'
 
 const MMContainer = styled.div.attrs({
 })`
@@ -82,14 +83,23 @@ class MeetingMediator extends Component {
             mediatorProps.user.username,
             mediatorProps.peerColors,
             mediatorProps.webRtcRiffIds,
+            null,
             this.updateAccessibleTable,
         );
     }
 
     render() {
         return (
-            <MMContainer id = "meeting-mediator">
-            </MMContainer>
+            <React.Fragment>
+                <MMContainer id = "meeting-mediator">
+                </MMContainer>
+                {this.state.tableRows.length ? (
+                    <ChartTable
+                        cols={['Participant', 'Amount of Speaking']}
+                        rows={this.state.tableRows}
+                    />
+                ) : null }
+            </React.Fragment>
         );
     }
 }

--- a/components/webrtc_view_bulma/MeetingMediator.jsx
+++ b/components/webrtc_view_bulma/MeetingMediator.jsx
@@ -20,13 +20,26 @@ const MMContainer = styled.div.attrs({
 
 class MeetingMediator extends Component {
     constructor(props) {
-        super(props)
+        super(props);
+        this.state = {
+            tableRows: []
+        };
+        this.namesById = this.getNamesById();
+        this.updateAccessibleTable = this.updateAccessibleTable.bind(this);
     }
 
-    componentDidUpdate() {
+    componentDidUpdate(prevProps) {
         //TODO: props.riff here has getters and setters and not values....????
         console.log("updating with participants:", this.props.riff.participants);
         let riffCopy = Object.assign({}, this.props.riff);
+
+        if (prevProps.webRtcPeers !== this.props.webRtcPeers ||
+            prevProps.user.id !== this.props.user.id ||
+            prevProps.user.username !== this.props.user.username
+        ) {
+            this.namesById = this.getNamesById();
+        }
+
         if (this.mm) {
             this.mm.update_users(riffCopy.participants);
         }
@@ -36,6 +49,25 @@ class MeetingMediator extends Component {
         console.log("MM props:", this.props);
         startRiffListener();
         this.startMM();
+    }
+
+    getNamesById() {
+        let namesById = this.props.webRtcPeers.reduce((memo, p) => {
+            const data = p.nick.split('|');
+            memo[data[0]] = data[1];
+            return memo;
+        }, {});
+        namesById[this.props.user.id] = this.props.user.username;
+        return namesById;
+    }
+
+    updateAccessibleTable(data) {
+        this.setState({
+            tableRows: data.turns.map(turn => [
+                this.namesById[turn.participant],
+                [`${Math.round(turn.turns * 100)}%`]
+            ])
+        });
     }
 
     startMM() {
@@ -50,6 +82,7 @@ class MeetingMediator extends Component {
             mediatorProps.user.username,
             mediatorProps.peerColors,
             mediatorProps.webRtcRiffIds,
+            this.updateAccessibleTable,
         );
     }
 

--- a/components/webrtc_view_bulma/charts/index.js
+++ b/components/webrtc_view_bulma/charts/index.js
@@ -7,7 +7,7 @@ class Mediator
     // COPIED FROM ORIGINAL RHYTHM-RTC PROJECT
     // with some minor modifications
 
-    constructor(app, participants, user, roomName, userName, peerColors, riffIds, localId)
+    constructor(app, participants, user, roomName, userName, peerColors, riffIds, localId, updateAccessibleTable)
     {
         console.log("Mediator initial state:", participants, user, roomName, userName);
 
@@ -22,6 +22,7 @@ class Mediator
         this.peerColors = peerColors;
         this.riffIds = riffIds;
         this.localId = localId;
+        this.updateAccessibleTable = updateAccessibleTable;
 
         // if (!elementIsEmpty('#meeting-mediator')) {
         //   console.log("not starting a second MM...");
@@ -93,9 +94,13 @@ class Mediator
 
         if (data.room === this.roomName && this.mm.data.participants.length > 1)
         {
-            this.mm.updateData({ participants: this.roomUsers,
-                                 transitions: data.transitions,
-                                 turns: this.transform_turns(this.roomUsers, data.turns) });
+            const mmdata = {
+                participants: this.roomUsers,
+                transitions: data.transitions,
+                turns: this.transform_turns(this.roomUsers, data.turns)
+            };
+            this.updateAccessibleTable(mmdata);
+            this.mm.updateData(mmdata);
         }
         else
         {

--- a/components/webrtc_view_bulma/charts/index.js
+++ b/components/webrtc_view_bulma/charts/index.js
@@ -1,15 +1,30 @@
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Riff Learning list overrides
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" }, "ObjectExpression": "first" }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+ */
+
+// This file only
+/* eslint-disable camelcase */
+
+import {logger} from 'utils/riff';
+
 import mediator from './mm.coffee';
 
 const MM = mediator.MeetingMediator;
 
-class Mediator
-{
+class Mediator {
     // COPIED FROM ORIGINAL RHYTHM-RTC PROJECT
     // with some minor modifications
 
-    constructor(app, participants, user, roomName, userName, peerColors, riffIds, localId, updateAccessibleTable)
-    {
-        console.log("Mediator initial state:", participants, user, roomName, userName);
+    constructor(app, participants, user, roomName, userName, peerColors, riffIds, localId, updateAccessibleTable) {
+        logger.debug('Mediator initial state:', participants, user, roomName, userName);
 
         this.mm = null;
         this.mm_width = 200;
@@ -25,14 +40,14 @@ class Mediator
         this.updateAccessibleTable = updateAccessibleTable;
 
         // if (!elementIsEmpty('#meeting-mediator')) {
-        //   console.log("not starting a second MM...");
+        //   logger.debug('not starting a second MM...');
         //   return;
         // }
 
         this.turns = this.app.service('turns');
-        console.log('>> Starting meeting mediator...');
-        console.log('MM participants:', this.roomUsers);
-        console.log("meeting mediator:", MM);
+        logger.debug('>> Starting meeting mediator...');
+        logger.debug('MM participants:', this.roomUsers);
+        logger.debug('meeting mediator:', MM);
         this.mm = new MM({participants: this.roomUsers,
                           transitions: 0,
                           turns: [],
@@ -46,28 +61,28 @@ class Mediator
         this.mm.render('#meeting-mediator');
 
         this.maybe_update_mm_turns = this.maybe_update_mm_turns.bind(this);
-        this.turns.on("updated", this.maybe_update_mm_turns);
+        this.turns.on('updated', this.maybe_update_mm_turns);
 
         this.handle_participantEvent_created = this.handle_participantEvent_created.bind(this);
-        //console.log("starting listening for participants");
+
+        //logger.debug('starting listening for participants');
         //this.app.service('participantEvents').on('created', this.handle_participantEvent_created);
 
         this.start_meeting_listener();
     }
 
     // just sums up values of the turns object.
-    get_total_transitions(turns)
-    {
+    get_total_transitions(turns) {
         return Object.values(turns).reduce((total, curval) => total + curval, 0);
     }
 
     // transform to the right data to send to chart
-    transform_turns(participants, turns)
-    {
-        console.log("transforming turns:", turns);
-        console.log("participants: ", participants);
+    transform_turns(participants, turns) {
+        logger.debug('transforming turns:', turns);
+        logger.debug('participants: ', participants);
+
         // filter out turns not by present participants
-        var filtered_turns = turns.filter(turn => participants.includes(turn.participant));
+        var filtered_turns = turns.filter((turn) => participants.includes(turn.participant));
         return filtered_turns;
     }
 
@@ -88,87 +103,80 @@ class Mediator
     //         _id: "5b183d0d1af76300111c871c"
     //         participant: "Mike"
     //         turns: 0.47058823529411764
-    maybe_update_mm_turns(data)
-    {
-        console.log("mm data turns:", data);
+    maybe_update_mm_turns(data) {
+        logger.debug('mm data turns:', data);
 
-        if (data.room === this.roomName && this.mm.data.participants.length > 1)
-        {
+        if (data.room === this.roomName && this.mm.data.participants.length > 1) {
             const mmdata = {
                 participants: this.roomUsers,
                 transitions: data.transitions,
-                turns: this.transform_turns(this.roomUsers, data.turns)
+                turns: this.transform_turns(this.roomUsers, data.turns),
             };
             this.updateAccessibleTable(mmdata);
             this.mm.updateData(mmdata);
-        }
-        else
-        {
+        } else {
             // wrong room, or not enough participants
-            //console.log('charts.maybe_update_mm_turns: wrong room, or not enough participants',
+            //logger.debug('charts.maybe_update_mm_turns: wrong room, or not enough participants',
             //             { room: data.room, expectedRoom: this.roomName, NumParticipants: this.mm.data.participants.length });
         }
     }
 
     // update MM participants if it matches this hangout.
     // removes the local participants from the list.
-    maybe_update_mm_participants()
-    {
-        console.log('charts.maybe_update_mm_participants:...');
+    maybe_update_mm_participants() {
+        logger.debug('charts.maybe_update_mm_participants:...');
+
         // if there's only one person in the room, we want the ball to be at the center.
         // i think this should be handled by the viz code, but it's not and i
         // don't really want to modify it
-        let newTurns = this.roomUsers.length > 1 ? this.mm.data.turns : [];
-        this.mm.updateData({ participants: this.roomUsers.slice(),
-                             transitions: this.mm.data.transitions,
-                             turns: newTurns.slice() });
+        const newTurns = this.roomUsers.length > 1 ? this.mm.data.turns : [];
+        this.mm.updateData({participants: this.roomUsers.slice(),
+                            transitions: this.mm.data.transitions,
+                            turns: newTurns.slice()});
     }
 
-    update_users(users)
-    {
-        console.log("charts.update_users:", { oldUsers: this.roomUsers, newUsers: users });
+    update_users(users) {
+        logger.debug('charts.update_users:', {oldUsers: this.roomUsers, newUsers: users});
         this.roomUsers = users.slice();
         this.maybe_update_mm_participants();
     }
 
-    handle_participantEvent_created(obj)
-    {
-        console.log("got a new participant event:", obj);
-        console.log("roomname:", this.roomName);
-        if (obj.room === this.roomName)
-        {
-            this.mm.updateData({ participants: obj.participants,
-                                 transitions: this.mm.data.transitions,
-                                 turns: this.mm.data.turns });
+    handle_participantEvent_created(obj) {
+        logger.debug('got a new participant event:', obj);
+        logger.debug(`roomname: ${this.roomName}`);
+        if (obj.room === this.roomName) {
+            this.mm.updateData({participants: obj.participants,
+                                transitions: this.mm.data.transitions,
+                                turns: this.mm.data.turns});
         }
     }
 
     start_meeting_listener() {
-        console.log("starting to listen for meeting changes");
+        logger.debug('starting to listen for meeting changes');
         var meetings = this.app.service('meetings');
-        meetings.on('patched', function (obj) {
-            console.log("meeting got updated:", obj);
-            console.log("roomname:", this.roomName);
+        meetings.on('patched', (obj) => {
+            logger.debug('meeting got updated:', obj);
+            logger.debug(`roomname: ${this.roomName}`);
             if (obj.room === this.roomName) {
-                console.log("room matches... updating meeting mediator")
+                logger.debug('room matches... updating meeting mediator');
                 this.mm.updateData({
                     participants: this.roomUsers,
                     transitions: this.mm.data.transitions,
-                    turns: this.mm.data.turns
+                    turns: this.mm.data.turns,
                 });
             }
-        }.bind(this));
+        });
     }
-
 }
 
-function elementIsEmpty(selector)
-{
-    let element = document.querySelector(selector);
-    if (element === null)
+// eslint-disable-next-line no-unused-vars
+function elementIsEmpty(selector) {
+    const element = document.querySelector(selector);
+    if (element === null) {
         throw new Error(`selector: '${selector}' did not reference any element in the document`);
+    }
 
     return element.childElementCount === 0;
 }
 
-export default Mediator
+export default Mediator;


### PR DESCRIPTION
#### Summary
This adds accessibility data tables to display the same data contained within the meeting mediator. No visual changes. Corresponds to https://github.com/rifflearning/riff-rtc/pull/106.

#### Ticket Link
rifflearning/zenhub#27

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
