### PR TITLE
Fix dashboard turn chart and influence chart

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ check-style:
     <<: *std_job
     stage: test
     script:
-        - make check-style-ci THRESHOLD=1757
+        - make check-style-ci THRESHOLD=1717
     artifacts:
         when: always
         paths:

--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -52,9 +52,7 @@ const dispatch = store.dispatch;
 const getState = store.getState;
 
 export function getCurrentPage(match) {
-    console.log("using match:",  match);
     if (match.params.path == 'pages') {
-        console.log("match returning", match.params.identifier)
         return match.params.identifier;
     } else {
         return null;

--- a/actions/global_actions.jsx
+++ b/actions/global_actions.jsx
@@ -19,7 +19,7 @@ import {Client4} from 'mattermost-redux/client';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
-import {getCurrentChannel, getCurrentChannelStats} from 'mattermost-redux/selectors/entities/channels';
+import {getCurrentChannelStats} from 'mattermost-redux/selectors/entities/channels';
 
 import {browserHistory} from 'utils/browser_history';
 import {loadChannelsForCurrentUser} from 'actions/channel_actions.jsx';
@@ -52,11 +52,11 @@ const dispatch = store.dispatch;
 const getState = store.getState;
 
 export function getCurrentPage(match) {
-    if (match.params.path == 'pages') {
+    if (match.params.path === 'pages') {
         return match.params.identifier;
-    } else {
-        return null;
     }
+
+    return null;
 }
 
 export function emitChannelClickEvent(channel) {

--- a/actions/views/dashboard.js
+++ b/actions/views/dashboard.js
@@ -244,7 +244,7 @@ export const processInfluence = (uid, utterances, meetingId) => { // eslint-disa
     let recentUttCounts = sortedUtterances.map((ut, idx) => {
         // get list of utterances within 2 seconds that are not by the speaker.
         const recentUtterances = sortedUtterances.slice(0, idx).filter((recentUt) => {
-            const timeDiff = getDurationInSeconds(ut.startTime, recentUt.endTime);
+            const timeDiff = getDurationInSeconds(recentUt.endTime, ut.startTime);
             const recent = timeDiff < 3 && timeDiff > 0;
             const sameParticipant = ut.participant === recentUt.participant;
             return recent && !sameParticipant;

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -47,6 +47,7 @@ const headerMarkdownOptions = {singleline: true, mentionHighlight: false, atMent
 const popoverMarkdownOptions = {singleline: false, mentionHighlight: false, atMentions: true};
 
 const SEARCH_BAR_MINIMUM_WINDOW_SIZE = 1140;
+const MAX_CHANNEL_MEMBERS_FOR_VIDEO = 7;
 
 export default class ChannelHeader extends React.Component {
     static propTypes = {
@@ -372,7 +373,7 @@ export default class ChannelHeader extends React.Component {
 
     webRtcDisabled = () => {
         return (!this.props.channelStats ||
-                this.props.channelStats.member_count > 7);
+                this.props.channelStats.member_count > MAX_CHANNEL_MEMBERS_FOR_VIDEO);
     }
 
     videoChatClicked = (e) => {
@@ -396,10 +397,10 @@ export default class ChannelHeader extends React.Component {
                     {'Riff chat is disabled until the page fully loads.'}
                 </span>
             );
-        } else if (this.props.channelStats.member_count > 7) {
+        } else if (this.props.channelStats.member_count > MAX_CHANNEL_MEMBERS_FOR_VIDEO) {
             tooltipContent = (
                 <span>
-                    {'Riff video chat only supports groups up to 7 people. Create a new DM group to start a call.'}
+                    {`Riff video chat only supports groups up to ${MAX_CHANNEL_MEMBERS_FOR_VIDEO} people. Create a new DM group to start a call.`}
                     <button
                         className='add-channel-btn cursor--pointer btn-primary btn'
                         style={{marginTop: '.5rem', marginBottom: '.5rem'}}
@@ -430,7 +431,7 @@ export default class ChannelHeader extends React.Component {
                 <Link
                     target='_blank'
                     id='videochat'
-                    to={this.webRtcDisabled() ? false : this.props.webRtcLink.pathname}
+                    to={this.webRtcDisabled() ? '' : this.props.webRtcLink.pathname}
                     onClick={(e) => this.videoChatClicked(e)}
                 >
                     <PopoverStickOnHover

--- a/components/channel_header/channel_header.jsx
+++ b/components/channel_header/channel_header.jsx
@@ -365,7 +365,7 @@ export default class ChannelHeader extends React.Component {
         const post = {
             message: `I started a Riff meeting! Join here: ${webRtcLink.href}`,
             channel_id: channelId,
-            pending_post_id: `${this.props.userId}:${time}`,
+            pending_post_id: `${this.props.currentUser.id}:${time}`,
             create_at: time,
         };
         return post;

--- a/components/webrtc_view_bulma/LeaveRoomButton.jsx
+++ b/components/webrtc_view_bulma/LeaveRoomButton.jsx
@@ -1,7 +1,16 @@
 // Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" } }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+ */
+
 import React from 'react';
+import PropTypes from 'prop-types';
 import {withRouter} from 'react-router-dom';
 import {connect} from 'react-redux';
 import MaterialIcon from 'material-icons-react';
@@ -31,16 +40,26 @@ const mapMergeProps = (stateProps, dispatchProps, ownProps) => ({
     },
 });
 
-const LeaveButtonView = ({leaveRoom}) => (
-    <button
-        className='button rounded is-danger'
-        style={{marginTop: '10px'}}
-        onClick={(event) => leaveRoom(event)}
-        aria-label='End call'
-    >
-        <MaterialIcon icon='call_end'/>
-    </button>
-);
+class LeaveButtonView extends React.Component {
+    static propTypes = {
+        meetingId: PropTypes.string,
+        uid: PropTypes.string.isRequired,
+        leaveRoom: PropTypes.func.isRequired,
+    };
+
+    render() {
+        return (
+            <button
+                className='button rounded is-danger'
+                style={{marginTop: '10px'}}
+                onClick={(event) => this.props.leaveRoom(event)}
+                aria-label='End call'
+            >
+                <MaterialIcon icon='call_end'/>
+            </button>
+        );
+    }
+}
 
 export default withRouter(connect(
     mapStateToProps,

--- a/components/webrtc_view_bulma/webrtc.jsx
+++ b/components/webrtc_view_bulma/webrtc.jsx
@@ -9,14 +9,14 @@
     "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
  */
 
-import React, {Component} from 'react';
+import React from 'react';
 import ReactDOM from 'react-dom';
-
-import {sendSurvey} from 'actions/survey_actions.jsx';
+import PropTypes from 'prop-types';
 
 import {addA11yBrowserAlert, readablePeers, logger} from 'utils/riff';
 import webrtc from 'utils/webrtc/webrtc';
 import store from 'stores/redux_store';
+import {sendSurvey} from 'actions/survey_actions.jsx';
 
 import RenderVideos from './RenderVideos';
 import WebRtcSidebar from './WebrtcSidebar';
@@ -24,10 +24,31 @@ import TextChat from './TextChat';
 
 // needs to be a regular component because we need to use
 // refs in order to request a local stream with SimpleWebRTC.
-class WebRtc extends Component {
+class WebRtc extends React.Component {
+    static propTypes = {
+        roomName: PropTypes.string.isRequired,
+        joinRoomStatus: PropTypes.string.isRequired,
+        joinRoomMessage: PropTypes.string.isRequired,
+        inRoom: PropTypes.bool.isRequired,
+        user: PropTypes.shape({
+            id: PropTypes.string,
+            username: PropTypes.string,
+            nickname: PropTypes.string,
+        }).isRequired,
+        riff: PropTypes.object.isRequired,
+        webRtcRemoteSharedScreen: PropTypes.object,
+        webRtcPeers: PropTypes.arrayOf(PropTypes.object).isRequired,
+        shouldFocusJoinRoomError: PropTypes.bool.isRequired,
+        focusJoinRoomErrorComplete: PropTypes.func.isRequired,
+        handleKeyPress: PropTypes.func,
+        handleReadyClick: PropTypes.func.isRequired,
+        clearJoinRoomError: PropTypes.func.isRequired,
+        dispatch: PropTypes.func.isRequired,
+    };
+
     constructor(props) {
         super(props);
-        logger.debug('webrt has these props:', props);
+        logger.debug('webrtc has these props:', props);
         this.onUnload = this.onUnload.bind(this);
         this.render = this.render.bind(this);
         this.reattachVideo = this.reattachVideo.bind(this);

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -116,7 +116,7 @@ export var app = feathers()
  */
 export function groupByPropertyValue(a, p) {
     return a.reduce((grouped, cur) => {
-        if (!(p in grouped)) {
+        if (!(cur[p] in grouped)) {
             grouped[cur[p]] = [];
         }
         grouped[cur[p]].push(cur);


### PR DESCRIPTION
#### Summary
Fix a couple of issues that were introduced by recent cleanup.
1. The turn chart is only using each participant's final utterance, instead of summing them all which was introduced in commit d6394028b351ffeb28a25db1b4aa71e4376051c4 (line 177) because of a bug in groupByPropertyValue introduced in 4417758444779dc3b1900e2ae416329987438896.
1. The influence chart algorithm accidentally changed to reverse the comparison of the times of utterances in commit d6394028b351ffeb28a25db1b4aa71e4376051c4 (line 247).

#### Ticket Link
#86

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Needs to be implemented in mobile (link to PR or User Story)
- [ ] Has server changes (please link)
- [ ] Has redux changes (please link)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
