### PR TITLE
Video chat performance tweaks - bitrate limitation and resolution/fps changes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ check-style:
     <<: *std_job
     stage: test
     script:
-        - make check-style-ci THRESHOLD=484
+        - make check-style-ci THRESHOLD=451
     artifacts:
         when: always
         paths:

--- a/components/webrtc_view_bulma/RemoteVideoContainer.jsx
+++ b/components/webrtc_view_bulma/RemoteVideoContainer.jsx
@@ -16,6 +16,7 @@
  *            MIT License (see https://opensource.org/licenses/MIT)
  *
  * ******************************************************************************/
+
 /* eslint
     header/header: "off",
     "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
@@ -24,7 +25,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { calculateBitrate, logger } from '../../utils/riff';
+import {calculateBitrate, logger} from 'utils/riff';
 
 import SharedScreen from './SharedScreen';
 import PeerVideo from './PeerVideo';
@@ -49,6 +50,9 @@ class RemoteVideoContainer extends React.Component {
 
         /** List of the IDs of all of the webrtc peers */
         riffIds: PropTypes.arrayOf(PropTypes.string),
+	
+	/** sets the outgoing bitrate limit for video streams */
+	setVideoBitrateLimit: PropTypes.func,
     };
 
     constructor(props) {

--- a/components/webrtc_view_bulma/RemoteVideoContainer.jsx
+++ b/components/webrtc_view_bulma/RemoteVideoContainer.jsx
@@ -50,9 +50,9 @@ class RemoteVideoContainer extends React.Component {
 
         /** List of the IDs of all of the webrtc peers */
         riffIds: PropTypes.arrayOf(PropTypes.string),
-	
-	/** sets the outgoing bitrate limit for video streams */
-	setVideoBitrateLimit: PropTypes.func,
+
+        /** sets the outgoing bitrate limit for video streams */
+        setVideoBitrateLimit: PropTypes.func,
     };
 
     constructor(props) {

--- a/components/webrtc_view_bulma/RemoteVideoContainer.jsx
+++ b/components/webrtc_view_bulma/RemoteVideoContainer.jsx
@@ -24,7 +24,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {logger} from '../../utils/riff';
+import { calculateBitrate, logger } from '../../utils/riff';
 
 import SharedScreen from './SharedScreen';
 import PeerVideo from './PeerVideo';
@@ -54,6 +54,11 @@ class RemoteVideoContainer extends React.Component {
     constructor(props) {
         super(props);
         logger.debug('remote video props:', props);
+    }
+
+    componentDidUpdate() {
+        const updatedBitrate = calculateBitrate(this.props.peers.length);
+        this.props.setVideoBitrateLimit(updatedBitrate);
     }
 
     peerVideo(peerLength) {

--- a/components/webrtc_view_bulma/RemoteVideoContainer.jsx
+++ b/components/webrtc_view_bulma/RemoteVideoContainer.jsx
@@ -56,9 +56,20 @@ class RemoteVideoContainer extends React.Component {
         logger.debug('remote video props:', props);
     }
 
-    componentDidUpdate() {
+    componentDidMount() {
+        // we have to do this here to make sure we set the bitrate
+        // in the case we join a meeting with peers already in it
         const updatedBitrate = calculateBitrate(this.props.peers.length);
         this.props.setVideoBitrateLimit(updatedBitrate);
+    }
+
+    componentDidUpdate(prevProps) {
+        // we check to make sure the peers array length has changed
+        // because we get a LOT of unnecessary re-renders in this codebase
+        if (prevProps.peers.length !== this.props.peers.length) {
+            const updatedBitrate = calculateBitrate(this.props.peers.length);
+            this.props.setVideoBitrateLimit(updatedBitrate);
+        }
     }
 
     peerVideo(peerLength) {

--- a/components/webrtc_view_bulma/RenderVideos.jsx
+++ b/components/webrtc_view_bulma/RenderVideos.jsx
@@ -35,7 +35,9 @@ class RenderVideos extends React.Component {
                             peers={this.props.webRtcPeers}
                             chat={this.props.chat}
                             remoteSharedScreen={this.props.webRtcRemoteSharedScreen}
-                            setVideoBitrateLimit={bitrateLimit => this.props.webrtc.setVideoBitrateLimit(bitrateLimit)}
+                            setVideoBitrateLimit={(bitrateLimit) => (
+                                this.props.webrtc.setVideoBitrateLimit(bitrateLimit)
+                            )}
                         />
                     </div>
                 </div>

--- a/components/webrtc_view_bulma/RenderVideos.jsx
+++ b/components/webrtc_view_bulma/RenderVideos.jsx
@@ -1,7 +1,17 @@
 // Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// Riff Learning lint overrides
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" }, "ObjectExpression": "first" }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+*/
+
 import React from 'react';
+import PropTypes from 'prop-types';
 import {ScaleLoader} from 'react-spinners';
 
 import {readablePeers, Colors} from 'utils/riff';
@@ -10,6 +20,53 @@ import RemoteVideoContainer from './RemoteVideoContainer';
 import * as sc from './styled';
 
 class RenderVideos extends React.Component {
+    static propTypes = {
+
+        chat: PropTypes.shape({
+            peerColors: PropTypes.array,
+            webRtcRiffIds: PropTypes.array,
+            webRtcPeerDisplayNames: PropTypes.array,
+        }).isRequired,
+
+        riff: PropTypes.shape({
+            meetingId: PropTypes.string,
+        }).isRequired,
+
+        webrtc: PropTypes.shape({
+            setVideoBitrateLimit: PropTypes.func,
+        }),
+
+        /** list of all peers to display */
+        webRtcPeers: PropTypes.arrayOf(PropTypes.object).isRequired,
+
+        /** If a Peer is sharing their screen, this will
+         *   have the remote shared screen element
+         *  Otherwise, this will be null
+         */
+        webRtcRemoteSharedScreen: PropTypes.object,
+
+        /** List of the IDs of all of the webrtc peers */
+        riffIds: PropTypes.arrayOf(PropTypes.string),
+
+        shouldFocusJoinRoomError: PropTypes.bool,
+        inRoom: PropTypes.bool.isRequired,
+        displayRoomName: PropTypes.bool,
+        roomName: PropTypes.string,
+        roRoomName: PropTypes.bool,
+        displayName: PropTypes.string,
+        roDisplayName: PropTypes.bool,
+        joinRoomStatus: PropTypes.string,
+        joinRoomMessage: PropTypes.string,
+        joinButtonDisabled: PropTypes.bool,
+
+        focusJoinRoomErrorComplete: PropTypes.func.isRequired,
+        handleDisplayNameChange: PropTypes.func,
+        clearJoinRoomError: PropTypes.func.isRequired,
+        handleRoomNameChange: PropTypes.func,
+        handleReadyClick: PropTypes.func.isRequired,
+        handleKeyPress: PropTypes.func,
+    };
+
     componentDidUpdate(prevProps /*, prevState*/) {
         //just updated DOM, which has an error message...focus on error
         if (!prevProps.shouldFocusJoinRoomError && this.props.shouldFocusJoinRoomError && this.JoinRoomErrorRef) {

--- a/components/webrtc_view_bulma/RenderVideos.jsx
+++ b/components/webrtc_view_bulma/RenderVideos.jsx
@@ -35,6 +35,7 @@ class RenderVideos extends React.Component {
                             peers={this.props.webRtcPeers}
                             chat={this.props.chat}
                             remoteSharedScreen={this.props.webRtcRemoteSharedScreen}
+                            setVideoBitrateLimit={bitrateLimit => this.props.webrtc.setVideoBitrateLimit(bitrateLimit)}
                         />
                     </div>
                 </div>

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "redux-persist-transform-filter": "0.0.18",
     "reselect": "3.0.1",
     "sibilant-webaudio": "github:rifflearning/sibilant#f62e2192ab2ab00f3a3dc4392af9c101329069d7",
-    "simplewebrtc": "github:rifflearning/SimpleWebRTC#25616eb081cbcca50ae2166fad9caf2c58fd0fa2",
+    "simplewebrtc": "github:rifflearning/SimpleWebRTC#783d8e763ff4a9d0d18c5be19c662bf09240d328",
     "smoothscroll-polyfill": "0.4.3",
     "socket.io-client": "^2.1.1",
     "styled-components": "^4.0.3",

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -302,7 +302,6 @@ export function readablePeers(peers) {
     return `${readablePeerList} are ${readableSuffix}`;
 }
 
-
 /** The minimum acceptable bitrate for a single stream */
 const MIN_BITRATE = 300; // kbps
 

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -301,3 +301,29 @@ export function readablePeers(peers) {
     // multiple peers
     return `${readablePeerList} are ${readableSuffix}`;
 }
+
+
+/** The minimum acceptable bitrate for a single stream */
+const MIN_BITRATE = 300; // kbps
+
+/** The maximum allowable total bandwidth consumed by all streams
+ *  given that our requirements state a minimum bandwidth
+ *  of 3 megabits per second, we come in just a bit below that
+ */
+const MAX_BANDWIDTH = 2700; // kbps
+
+/**
+ * Returns the appropriate bitrate (kbps) for the video streams
+ * based on the number of other peers in the meeting
+ * (e.g. if 2 total people are in a meeting, peerCount is 1)
+ */
+export function calculateBitrate(peerCount) {
+  // if we have four or more peers,
+  // we just want to use the lowest possible bitrate
+  // to avoid any cpu limitations
+  if (peerCount >= 4) {
+    return MIN_BITRATE;
+  }
+
+  return MAX_BANDWIDTH / peerCount;
+}

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -318,12 +318,12 @@ const MAX_BANDWIDTH = 2700; // kbps
  * (e.g. if 2 total people are in a meeting, peerCount is 1)
  */
 export function calculateBitrate(peerCount) {
-  // if we have four or more peers,
-  // we just want to use the lowest possible bitrate
-  // to avoid any cpu limitations
-  if (peerCount >= 4) {
-    return MIN_BITRATE;
-  }
+    // if we have four or more peers,
+    // we just want to use the lowest possible bitrate
+    // to avoid any cpu limitations
+    if (peerCount >= 4) {
+        return MIN_BITRATE;
+    }
 
-  return MAX_BANDWIDTH / peerCount;
+    return MAX_BANDWIDTH / peerCount;
 }

--- a/utils/webrtc/webrtc.js
+++ b/utils/webrtc/webrtc.js
@@ -46,13 +46,15 @@ export default function (localVideoNode, dispatch, getState) {
         },
         media: {
             audio: true,
-            // TODO - the resolution here is rather low
-            // this is good for cpu limited users,
-            // but in the future we would like to implement variable resolution
-            // to improve visual quality for those who can afford it
             video: {
+
+                // TODO - the resolution here is rather low
+                // this is good for cpu limited users,
+                // but in the future we would like to implement variable resolution
+                // to improve visual quality for those who can afford it
                 width: {ideal: 320},
                 height: {ideal: 240},
+
                 // firefox doesn't support requesting a framerate other than
                 // that which the user's webcam can natively provide
                 // chrome does not have this limitation

--- a/utils/webrtc/webrtc.js
+++ b/utils/webrtc/webrtc.js
@@ -35,7 +35,6 @@ export function isScreenShareSourceAvailable() {
 }
 
 export default function (localVideoNode, dispatch, getState) {
-    //TODO: make dynamic
     const webRtcConfig = {
         localVideoEl: localVideoNode,
         remoteVideosEl: '',
@@ -47,10 +46,17 @@ export default function (localVideoNode, dispatch, getState) {
         },
         media: {
             audio: true,
+            // TODO - the resolution here is rather low
+            // this is good for cpu limited users,
+            // but in the future we would like to implement variable resolution
+            // to improve visual quality for those who can afford it
             video: {
-                width: {ideal: 640},
-                height: {ideal: 480},
-                frameRate: {max: 30},
+                width: {ideal: 320},
+                height: {ideal: 240},
+                // firefox doesn't support requesting a framerate other than
+                // that which the user's webcam can natively provide
+                // chrome does not have this limitation
+                frameRate: {ideal: 12, max: 30},
             },
         },
         debug: true,

--- a/utils/webrtc/webrtc.js
+++ b/utils/webrtc/webrtc.js
@@ -1,6 +1,15 @@
 // Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+// Riff Learning lint overrides
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" }, "ObjectExpression": "first" }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+*/
+
 import SimpleWebRtc from 'simplewebrtc';
 import Sibilant from 'sibilant-webaudio';
 import parse from 'url-parse';
@@ -34,7 +43,7 @@ export function isScreenShareSourceAvailable() {
         Boolean(navigator.mediaDevices.getSupportedConstraints().mediaSource));
 }
 
-export default function (localVideoNode, dispatch, getState) {
+export default function createAndInitializeWebRTC(localVideoNode, dispatch, getState) {
     const webRtcConfig = {
         localVideoEl: localVideoNode,
         remoteVideosEl: '',
@@ -167,7 +176,7 @@ export default function (localVideoNode, dispatch, getState) {
         dispatch(WebRtcActions.readyToCall());
     });
 
-    webrtc.changeNick = function (nick) {
+    webrtc.changeNick = function changeNick(nick) {
         this.config.nick = nick;
         this.webrtc.config.nick = nick;
     };


### PR DESCRIPTION
#### Summary
This change reduces the requested resolution / frame rate from the user's webcam and limits the video bitrate based on the number of users in a meeting.

Fully peer-to-peer webrtc implementations are very taxing on the end-user. Limiting the resolution / frame rate / bitrate of the video streams provides a significant reduction in CPU usage and bandwidth consumption for the user, which previously was very high. This change allows us to support users with less powerful computers & lower capacity network changes, with the trade-off of lower maximum video quality for users whose machines / network connections can support it.

This is an adaptation of the changes to riff-rtc (see https://github.com/rifflearning/riff-rtc/pull/138). The biggest change is we aren't setting video bitrate every time the component updates, because the component seems to re-render every two seconds are so (which is maybe something we should consider fixing - it's not clear to me what the effects of this on performance are). 
