### PR TITLE
disable all existing unit tests & create new directory for riff tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,8 @@
     ],
     "testPathIgnorePatterns": [
       "/node_modules/",
-      "/non_npm_dependencies/"
+      "/non_npm_dependencies/",
+      "/tests/"
     ],
     "clearMocks": true,
     "collectCoverageFrom": [

--- a/riff_tests/setup.js
+++ b/riff_tests/setup.js
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import Adapter from 'enzyme-adapter-react-16';
+import {configure} from 'enzyme';
+import $ from 'jquery';
+
+global.$ = $;
+global.jQuery = $;
+global.performance = {};
+
+configure({adapter: new Adapter()});
+
+const supportedCommands = ['copy'];
+
+Object.defineProperty(document, 'queryCommandSupported', {
+    value: (cmd) => supportedCommands.includes(cmd),
+});
+
+Object.defineProperty(document, 'execCommand', {
+    value: (cmd) => supportedCommands.includes(cmd),
+});
+
+let logs;
+let warns;
+let errors;
+beforeAll(() => {
+    console.originalLog = console.log;
+    console.log = jest.fn((...params) => {
+        console.originalLog(...params);
+        logs.push(params);
+    });
+
+    console.originalWarn = console.warn;
+    console.warn = jest.fn((...params) => {
+        console.originalWarn(...params);
+        warns.push(params);
+    });
+
+    console.originalError = console.error;
+    console.error = jest.fn((...params) => {
+        console.originalError(...params);
+        errors.push(params);
+    });
+});
+
+beforeEach(() => {
+    logs = [];
+    warns = [];
+    errors = [];
+});
+
+afterEach(() => {
+    if (logs.length > 0 || warns.length > 0 || errors.length > 0) {
+        throw new Error('Unexpected console logs' + logs + warns + errors);
+    }
+});

--- a/riff_tests/utils/emoticons.test.jsx
+++ b/riff_tests/utils/emoticons.test.jsx
@@ -1,0 +1,33 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import * as Emoticons from 'utils/emoticons.jsx';
+
+describe('Emoticons', () => {
+    describe('handleEmoticons', () => {
+        test('should replace emoticons with tokens', () => {
+            expect(Emoticons.handleEmoticons(':goat: :dash:', new Map())).
+                toEqual('$MM_EMOTICON0$ $MM_EMOTICON1$');
+        });
+
+        test('should replace emoticons not separated by whitespace', () => {
+            expect(Emoticons.handleEmoticons(':goat::dash:', new Map())).
+                toEqual('$MM_EMOTICON0$$MM_EMOTICON1$');
+        });
+
+        test('should replace emoticons separated by punctuation', () => {
+            expect(Emoticons.handleEmoticons('/:goat:..:dash:)', new Map())).
+                toEqual('/$MM_EMOTICON0$..$MM_EMOTICON1$)');
+        });
+
+        test('should replace emoticons separated by text', () => {
+            expect(Emoticons.handleEmoticons('asdf:goat:asdf:dash:asdf', new Map())).
+                toEqual('asdf$MM_EMOTICON0$asdf$MM_EMOTICON1$asdf');
+        });
+
+        test('shouldn\'t replace invalid emoticons', () => {
+            expect(Emoticons.handleEmoticons(':goat : : dash:', new Map())).
+                toEqual(':goat : : dash:');
+        });
+    });
+});

--- a/riff_tests/utils/riff/index.test.js
+++ b/riff_tests/utils/riff/index.test.js
@@ -1,0 +1,15 @@
+import assert from 'assert';
+
+import {readablePeers} from 'utils/riff';
+
+// Proof of concept test - still needs to be fleshed out
+describe('Riff Utils', () => {
+    describe('readablePeers', () => {
+        it('handles empty array', () => {
+            assert.equal(
+                readablePeers([]),
+                'Nobody else is here.',
+            );
+        });
+    });
+});


### PR DESCRIPTION
#### Summary
 - Disabled existing tests since we weren't running them anyway
  (many were broken / unreliable)
 - created riff_tests to house all new unit tests until we fix
   the existing ones
 - added an existing test from mattermost that we knew worked
 - added a new proof of concept test for a utility function written
   by riff & verified that bad tests fail

Note that this does technically introduce additional style issues, but they're kind of unreasonable and mostly due to already existing mattermost code that we copied over

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Added or updated unit tests (required for all new features)
