### PR TITLE
Add a user interaction network graph to the dashboard

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ check-style:
     <<: *std_job
     stage: test
     script:
-        - make check-style-ci THRESHOLD=64
+        - make check-style-ci THRESHOLD=54
     artifacts:
         when: always
         paths:

--- a/components/dashboard/DashboardView.jsx
+++ b/components/dashboard/DashboardView.jsx
@@ -10,6 +10,8 @@ import * as UserAgent from 'utils/user_agent.jsx';
 import {logger} from 'utils/riff';
 
 import MeetingViz from './components/MeetingViz';
+import {CourseConnections} from './components/CourseConnections';
+import {SectionHeader} from './components/SectionHeader';
 
 const LoadingErrorMessage = styled.div.attrs({
     className: 'loading-error-message',
@@ -21,6 +23,27 @@ const LoadingErrorMessage = styled.div.attrs({
     text-align: center;
     color: #4a4a4a;
     font-size: 28px;
+`;
+
+const DashboardOuterContainer = styled.div.attrs({
+    className: 'dashboard-outer-container',
+})`
+    overflow-y: scroll;
+`;
+
+const DashboardInnerContainer = styled.div.attrs({
+    className: 'dashboard-inner-container',
+})`
+    width: 96%;
+    margin: 0 auto;
+`;
+
+const CourseConnectionsContainer = styled.div.attrs({
+    className: 'course-connections-container',
+})`
+    position: relative;
+    height: 60vh;
+    margin: 2rem 0;
 `;
 
 // TODO Add dispatch and click
@@ -131,25 +154,63 @@ class DashboardView extends React.Component {
             );
         });
 
+        const dashboardHeader = (
+            <SectionHeader
+                title={'Riff Dashboard'}
+                desc={'Your dashboard shows you metrics about how you interact with your coursemates in Riff video and chat. Use these metrics to track and understand how you engage with your peers.'}
+                mainHeader={true}
+            />
+        );
+
+        const courseConnectionsHeader = (
+            <SectionHeader
+                title={'Your Course Connections'}
+                desc={'Learners with lots of peer engagement do better in the course. Use this network graph to track and monitor your progress.'}
+            />);
+
+        const meetingsSectionHeader = (
+            <SectionHeader
+                title={'Your Conversations'}
+                desc={'High-functioning groups allow everyone to contribute. Use Riff video metrics to see how your group interacts, and change conversational behaviors that aren\'t working.'}
+            />
+        );
+
         const component = () => {
             //errored (catch all static message is shown, these errors are all related to having no meetings)
             if (this.props.loadingError.status) {
                 return (
-                    <LoadingErrorMessage>
-                        <div>{'Welcome to your Riff Dashboard!'}</div>
-                        <br/>
-                        <div>{'Once you have a Riff video meeting,'}</div>
-                        <div>{'your Riff stats will display here.'}</div>
-                    </LoadingErrorMessage>
+                    <DashboardOuterContainer>
+                        <DashboardInnerContainer>
+                            {dashboardHeader}
+                            {courseConnectionsHeader}
+                            <CourseConnectionsContainer>
+                                <CourseConnections/>
+                            </CourseConnectionsContainer>
+                            {meetingsSectionHeader}
+                            <div style={{position: 'relative', height: '50vh'}}>
+                                <LoadingErrorMessage>
+                                    <div>{'Once you have a Riff video meeting, your metrics will display here.'}</div>
+                                </LoadingErrorMessage>
+                            </div>
+                        </DashboardInnerContainer>
+                    </DashboardOuterContainer>
                 );
             }
 
             //meetings
             if (this.props.meetings.length > 0) {
                 return (
-                    <div style={{overflowY: 'scroll'}}>
-                        {meetingVisualizations}
-                    </div>
+                    <DashboardOuterContainer>
+                        <DashboardInnerContainer>
+                            {dashboardHeader}
+                            {courseConnectionsHeader}
+                            <CourseConnectionsContainer>
+                                <CourseConnections/>
+                            </CourseConnectionsContainer>
+                            {meetingsSectionHeader}
+                            {meetingVisualizations}
+                        </DashboardInnerContainer>
+                    </DashboardOuterContainer>
                 );
             }
 

--- a/components/dashboard/DashboardView.jsx
+++ b/components/dashboard/DashboardView.jsx
@@ -2,8 +2,11 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import $ from 'jquery';
 
+import * as UserAgent from 'utils/user_agent.jsx';
 import {logger} from 'utils/riff';
 
 import MeetingViz from './components/MeetingViz';
@@ -16,7 +19,7 @@ const LoadingErrorMessage = styled.div.attrs({
     left: 50%;
     transform: translate(-50%,-50%);
     text-align: center;
-    color: #4A4A4A;
+    color: #4a4a4a;
     font-size: 28px;
 `;
 
@@ -24,50 +27,147 @@ const LoadingErrorMessage = styled.div.attrs({
 
 // All dispatches were ripped out re-copy back in once server is working
 
-const DashboardView = (props) => {
-    logger.debug('only loading:', props.numMeetingsToDisplay, 'Meetings');
-    const meetingVisualizations = props.meetings.slice(0, props.numMeetingsToDisplay).map((m) => {
-        return (
-            <MeetingViz
-                key={m._id}
-                meeting={m}
-                allMeetings={props.meetings}
-                maybeLoadNextMeeting={props.maybeLoadNextMeeting}
-                user={props.user}
-            />
-        );
-    });
-    const component = () => {
-        //errored (catch all static message is shown, these errors are all related to having no meetings)
-        if (props.loadingError.status) {
-            return (
-                <LoadingErrorMessage>
-                    <div>{'Welcome to your Riff Dashboard!'}</div>
-                    <br/>
-                    <div>{'Once you have a Riff video meeting,'}</div>
-                    <div>{'your Riff stats will display here.'}</div>
-                </LoadingErrorMessage>
-            );
-        }
+/* ******************************************************************************
+ * DashboardView                                                           */ /**
+ *
+ * React component to present the Riff Metrics for meetings the user attended
+ *
+ ********************************************************************************/
+class DashboardView extends React.Component {
+    static propTypes = {
 
-        //meetings
-        if (props.meetings.length > 0) {
-            return (
-                <div style={{overflowY: 'scroll'}}>
-                    {meetingVisualizations}
-                </div>
-            );
-        }
+        /** riffdata authorization token */
+        riffAuthToken: PropTypes.string,
 
-        //default
-        return false;
+        /** The current mattermost user */
+        user: PropTypes.object.isRequired,
+
+        /** The list of meeting objects to be presented */
+        meetings: PropTypes.arrayOf(PropTypes.object).isRequired,
+
+        /** The number of meetings to display in the scrolling list */
+        numMeetingsToDisplay: PropTypes.number.isRequired,
+
+        /** ??? I'm not sure what the value signifies -mjl 2019-09-02 */
+        shouldFetch: PropTypes.bool.isRequired,
+
+        /** ??? */
+        loadingError: PropTypes.object.isRequired,
+
+        /** function to set up the connection to the riffdata server if it doesn't exist yet */
+        authenticateRiff: PropTypes.func.isRequired,
+
+        /** function to load the meetings for a particular user (it had better be the current user) */
+        loadRecentMeetings: PropTypes.func.isRequired,
+
+        /** ??? */
+        maybeLoadNextMeeting: PropTypes.func.isRequired,
     };
 
-    return (
-        <div className='app__content'>
-            {component()}
-        </div>
-    );
-};
+    /* **************************************************************************
+     * componentDidMount                                                   */ /**
+     *
+     * Lifecycle method of a React component.
+     * This is invoked immediately after a component is mounted (inserted into the
+     * tree). Initialization that requires DOM nodes should go here.
+     *
+     * Load the user's list of meetings. As this may be a time consuming operation
+     * we wait until this page is mounted and we know that the list is actually
+     * needed.
+     *
+     * @see {@link https://reactjs.org/docs/react-component.html#componentdidmount|React.Component.componentDidMount}
+     */
+    componentDidMount() {
+        if (this.props.riffAuthToken) {
+            logger.debug(`DashboardView.didMount: going to load recent meetings for ${this.props.user.id}`);
+            this.props.loadRecentMeetings(this.props.user.id);
+        }
 
-export default DashboardView;
+        $('body').addClass('app__body');
+
+        // IE Detection
+        if (UserAgent.isInternetExplorer() || UserAgent.isEdge()) {
+            $('body').addClass('browser--IE');
+        }
+    }
+
+    componentDidUpdate() {
+        if (this.props.riffAuthToken && this.props.shouldFetch) {
+            this.props.loadRecentMeetings(this.props.user.id);
+        }
+    }
+
+    /**
+     * TODO: remove this functionality from here. I'm not sure why it has to be here anyway -mjl 2019-09-02
+     */
+    UNSAFE_componentWillMount() { // eslint-disable-line camelcase
+        logger.debug('DashboardView.willMount: user:', this.props.user);
+        if (!this.props.riffAuthToken) {
+            this.props.authenticateRiff();
+        }
+    }
+
+    // componentWillUnmount() {
+    //     $('body').removeClass('app__body');
+    // }
+
+    /* **************************************************************************
+     * render                                                              */ /**
+     *
+     * Required method of a React component.
+     * @see {@link https://reactjs.org/docs/react-component.html#render|React.Component.render}
+     */
+    render() {
+        logger.debug(`DashboardView.render: only loading: ${this.props.numMeetingsToDisplay} Meetings`);
+        const meetingVisualizations = this.props.meetings.slice(0, this.props.numMeetingsToDisplay).map((m) => {
+            return (
+                <MeetingViz
+                    key={m._id}
+                    meeting={m}
+                    allMeetings={this.props.meetings}
+                    maybeLoadNextMeeting={this.props.maybeLoadNextMeeting}
+                    user={this.props.user}
+                />
+            );
+        });
+
+        const component = () => {
+            //errored (catch all static message is shown, these errors are all related to having no meetings)
+            if (this.props.loadingError.status) {
+                return (
+                    <LoadingErrorMessage>
+                        <div>{'Welcome to your Riff Dashboard!'}</div>
+                        <br/>
+                        <div>{'Once you have a Riff video meeting,'}</div>
+                        <div>{'your Riff stats will display here.'}</div>
+                    </LoadingErrorMessage>
+                );
+            }
+
+            //meetings
+            if (this.props.meetings.length > 0) {
+                return (
+                    <div style={{overflowY: 'scroll'}}>
+                        {meetingVisualizations}
+                    </div>
+                );
+            }
+
+            //default
+            return false;
+        };
+
+        return (
+            <div className='app__content'>
+                {component()}
+            </div>
+        );
+    }
+}
+
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    DashboardView,
+};

--- a/components/dashboard/components/ChartCard.jsx
+++ b/components/dashboard/components/ChartCard.jsx
@@ -32,6 +32,11 @@ const ChartDiv = styled.div.attrs({
     .sigma-scene: {
         left: 0px;
     }
+
+    ${(props) => props.isNetworkGraphCard === true && `
+        padding-bottom: 0;
+        height: 100%;
+    `}
 `;
 
 const Card = styled.div.attrs({
@@ -43,6 +48,11 @@ const Card = styled.div.attrs({
     max-width: ${(props) => `${props.maxWidth}vw`};
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
     border: none;
+
+    ${(props) => props.isNetworkGraphCard === true && `
+        height: 100%;
+        max-width: 100%;
+    `}
 
     ${(props) => props.isMediatorCard === true && `
       box-shadow: none;
@@ -112,6 +122,7 @@ const ChartCard = enhance((props) => {
         <Card
             maxWidth={maxWidth}
             isMediatorCard={props.isMediatorCard}
+            isNetworkGraphCard={props.isNetworkGraphCard}
         >
             <CardTitle>
                 {props.title}
@@ -137,7 +148,7 @@ const ChartCard = enhance((props) => {
                     longDescription={props.longDescription}
                 />
             )}
-            <ChartDiv>
+            <ChartDiv isNetworkGraphCard={props.isNetworkGraphCard}>
                 {props.chartTable}
                 {props.chartDiv}
             </ChartDiv>

--- a/components/dashboard/components/CourseConnections/CourseConnectionsView.jsx
+++ b/components/dashboard/components/CourseConnections/CourseConnectionsView.jsx
@@ -1,0 +1,646 @@
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as am4core from '@amcharts/amcharts4/core';
+import * as am4plugins_forceDirected from '@amcharts/amcharts4/plugins/forceDirected'; // eslint-disable-line camelcase
+
+import {InteractionContext} from 'utils/riff/user_analytic_utils';
+
+import {
+    cmpObjectProp,
+    getColorForLearningGroup,
+    logger,
+    networkGraphNodeColors as nodeColors,
+} from 'utils/riff';
+
+import ChartCard from '../ChartCard';
+
+// Store all constants to be used throughout the graph
+// Keep all magic numbers in one place for ease of future alteration
+const graphConfigurationValues = {
+    outerCircleStrokeWidth: 3, // Width in pixels of the secondary cirle around nodes with children
+    minNodeRadius: 20, // Minimum pixel radius for nodes
+    graphCenterStrength: 0.3, // Determines the strength of attraction of nodes to the center of the graph
+    nodeLinkWidth: 2, // Pixel width of links
+    nodeLinkOpacity: 1, // Default opacity of links
+    youNode: {
+        nodeLabel: { // Configuration for the label on the 'You' node
+            fontSize: '20',
+            fontWeight: 'bold',
+            fill: nodeColors.you.fontColor,
+        },
+        nodeWidth: 3, // The relative width of the 'You' node
+    },
+    userNodes: {
+        uncontactedNodeOpacity: 0.3, // Opacity of nodes for group members which you had no contact with
+        uncontactedLinkOpacity: 0, // Opacity of node links for group members which you had no contact with
+        nodeWidth: 0.5, // The relative width of user nodes
+    },
+    courseNode: {
+        linkDistance: 2, // The relative distance between the course node and its parent
+    },
+    interactionContextNodes: {
+        nodeWidth: 1, // The relative width of user nodes
+    },
+};
+
+/* ******************************************************************************
+ * CourseConnectionsView                                                   */ /**
+ *
+ * React component to render a network graph to visualise this user's interactions
+ * in the selected Mattermost team (course).
+ *
+ ********************************************************************************/
+class CourseConnectionsView extends React.Component {
+    static propTypes = {
+
+        /** An array of user interactions in the current MM team that the current user was involved in */
+        userInteractions: PropTypes.array,
+
+        /** An array of learning groups that the current user is a member of */
+        userLearningGroups: PropTypes.array,
+
+        /** An array of all potential learning group types in this MM team (course) */
+        learningGroupTypes: PropTypes.array,
+
+        /** A boolean denoting whether or not the user interactions request has completed successfully */
+        isUserInteractionsLoaded: PropTypes.bool.isRequired,
+
+        /** An object containing details about the current user */
+        currentUser: PropTypes.object.isRequired,
+
+        /** The id of the currently selected MM team */
+        currentTeamId: PropTypes.string.isRequired,
+
+        /** Used to fetch user interactions data for the current user and selected MM team */
+        fetchUserInteractions: PropTypes.func,
+    };
+
+    constructor(props) {
+        super(props);
+
+        this.chart = null;
+        this.series = null;
+        this.sortedLearningGroupTypes = [];
+
+        // amchart adapter handler function needs to be bound to this
+        this.getChartNodeColor = this.getChartNodeColor.bind(this);
+    }
+
+    componentDidMount() {
+        // Create the chart (attach to the div now mounted in the DOM, and do initial configuration)
+        this.configureGraph();
+
+        // Fetch user interactions data for the current user in the current MM team
+        this.props.fetchUserInteractions(this.props.currentUser.id, this.props.currentTeamId);
+    }
+
+    componentDidUpdate() {
+        if (this.props.isUserInteractionsLoaded) {
+            // There may be no learning group types if the team is not for an LMS course
+            if (this.props.learningGroupTypes) {
+                // The sorting is done on the server in a later version
+                // TODO: Remove once the newer version of the mm-server is in use
+                this.sortedLearningGroupTypes = [...this.props.learningGroupTypes].sort(cmpObjectProp('prefix'));
+            }
+            else {
+                this.sortedLearningGroupTypes = [];
+            }
+
+            logger.debug('CourseConnectionsView.didUpdate: drawing graph', this.props, this.sortedLearningGroupTypes);
+
+            // Re-render the graph (this updates the DOM tree at the element w/ id='network-graph-div')
+            this.drawGraph();
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.chart) {
+            this.chart.dispose();
+            this.chart = null;
+            logger.debug('CourseConnectionsView.willUnmount: disposed of chart');
+        }
+    }
+
+    render() {
+        const chartInfo = 'This metric shows how many times you\'ve connected with members of your group(s) and other people in the course.' +
+        ' Connections are a total of your direct messages, mentions, replies, and reactions in Riff.' +
+        '\n Learners who engage with their peers are more likely to complete the course, and have higher grades.';
+
+        const networkGraph = <div id='network-graph-div' style={{width: '100%', height: '100%'}}/>;
+
+        return (
+
+            <ChartCard
+                title={'Course Interactions'}
+                chartDiv={networkGraph}
+                chartInfo={chartInfo}
+                chartTable={false}
+                chartCardId={'cc-network-graph'}
+                isNetworkGraphCard={true}
+            />
+        );
+    }
+
+    /**
+     * Initializes all the initial configurations for the graph and
+     * places it in the DOM
+     *
+     * updates this.chart and this.series
+     *
+     * @returns {Object} containing a reference to the graph for adding nodes, etc
+     */
+    configureGraph() {
+        // Hide am-charts logo (paid version)
+        am4core.options.commercialLicense = true;
+
+        // Create chart and place it inside the html element with id network-graph-div
+        const chart = am4core.create('network-graph-div', am4plugins_forceDirected.ForceDirectedTree);
+        this.chart = chart;
+
+        // Create network graph (force directed chart)
+        const series = chart.series.push(new am4plugins_forceDirected.ForceDirectedSeries());
+        this.series = series;
+
+        series.minRadius = graphConfigurationValues.minNodeRadius; // Minimum pixel radius for nodes
+        series.centerStrength = graphConfigurationValues.graphCenterStrength; // Determines the strength of attraction of nodes to the center of the graph
+
+        // Set up data fields
+        // These datafields are used in each node's configuration
+        series.dataFields.children = 'children'; // An array to store children of each node
+        series.dataFields.value = 'nodeWidth'; // Determines the size of each node
+        series.dataFields.name = 'nodeLabel'; // Determines the label on each node
+
+        // Configure tooltips
+        series.tooltip.getFillFromObject = false; // Don't use the color of the node as the background of the corresponding tooltip
+        series.tooltip.configField = 'configTooltip'; // Use the configTooltip property in each node's configuration to the configure tooltips
+
+        // Configure Nodes
+        const nodeTemplate = series.nodes.template;
+        nodeTemplate.configField = 'config'; // A configuration object for each node
+        nodeTemplate.label.text = '{name}'; // Link to name property in node's configuration
+
+        // Configure node links
+        const linkTemplate = series.links.template;
+        linkTemplate.strokeWidth = graphConfigurationValues.nodeLinkWidth; // Pixel width of links
+        linkTemplate.strokeOpacity = graphConfigurationValues.nodeLinkOpacity; // Default opacity of links
+        linkTemplate.configField = 'configLink'; // Use the configLink property in each node's configuration to the configure that node's links to its children
+        linkTemplate.adapter.add('stroke', this.getChartNodeColor); // set the link color based on the node context type
+
+        // Add the base 'you' node to the graph
+        series.data = [this.getYouNode()];
+
+        return series;
+    }
+
+    /**
+     * Draw the graph w/ the latest interaction data
+     */
+    drawGraph() {
+        const {userInteractions, userLearningGroups} = this.props;
+        const learningGroupTypes = this.sortedLearningGroupTypes;
+
+        // Get a reference to the 'You' node
+        const youNode = this.series.data[0];
+
+        // Update the label on the 'You' node w/ the user interaction count
+        youNode.nodeLabel = this.getNodeLabel({
+            label: 'You',
+            interactionCount: userInteractions ? userInteractions.length : 0,
+        });
+
+        // Remove any child nodes from the 'You' node (we'll add back any child nodes that
+        // should still exist based on the current userInteractions)
+        youNode.children = [];
+
+        // If there are no user interactions for the current user, then return
+        // Only the 'You' node will be shown
+        if (!userInteractions) {
+            return false;
+        }
+
+        // Now get the course interaction context and any learning group contexts
+        // and add their chart node data as child nodes of the top level 'you' node.
+
+        const courseContext = this.getCourseContext();
+
+        // If the user has interactions in the course context then
+        // add its node as a child of the 'you' node, otherwise we don't want to see it.
+        // (we determine this by seeing if it's node has any child nodes since we
+        // have only added a child node if it had interactions)
+        if (courseContext.chartNodeData.children.length > 0) {
+            youNode.children.push(courseContext.chartNodeData);
+        }
+
+        // This is a sanity check (assert) error log message
+        // If the user is a member of a learning group, then there MUST be learning group types
+        // otherwise something is amiss.
+        if (userLearningGroups && userLearningGroups.length > 0 && !(learningGroupTypes && learningGroupTypes.length > 0)) {
+            logger.error('NetworkGraphview.drawGraph: logic error: user is in a learning group but there are no learning group types!', this.props);
+        }
+
+        // If this user is a member of learning groups then create interaction contexts for
+        // all of them.
+        let learningGroupContexts = null;
+        if (userLearningGroups && userLearningGroups.length > 0) {
+            learningGroupContexts = this.getLearningGroupContexts();
+
+            // Add all the learningGroupContext's nodes as children of the 'you' node
+            for (const lgContext of Object.values(learningGroupContexts)) {
+                youNode.children.push(lgContext.chartNodeData);
+            }
+        }
+
+        logger.debug('NetworkGraphview.drawGraph: interaction contexts', courseContext, learningGroupContexts);
+
+        // Force the chart to reload the data we just updated
+        this.series.invalidateData();
+
+        logger.debug('NetworkGraphview.drawGraph: you node', youNode);
+
+        return false;
+    }
+
+    /**
+     * Create a node configuration and generate an InteractionContext object for the course
+     * Loop over all interactions that occurred in the course context and group them into
+     * UserInContext objects for each user, counting the interaction types respectively
+     *
+     * @returns {InteractionContext} containing the chart node data for the course node
+     */
+    getCourseContext() {
+        const contextType = 'course';
+        const contextName = 'course';
+
+        // Get user's interactions in the course context
+        const courseInteractions = this.props.userInteractions.filter((interaction) => {
+            return interaction.context === contextType;
+        });
+
+        const interactionCount = courseInteractions.length;
+
+        const nodeConfig = {
+            nodeLabel: this.getNodeLabel({
+                label: contextType,
+                interactionCount,
+            }),
+            color: this.getNodeColor({nodeContext: contextType}),
+            nodeWidth: graphConfigurationValues.interactionContextNodes.nodeWidth,
+            configLink: {
+                distance: graphConfigurationValues.courseNode.linkDistance,
+            },
+            nodeInfo: {
+                contextType,
+            },
+            config: {
+                tooltipHTML: this.getContextTooltip({
+                    contextName,
+                    interactionCount,
+                }),
+            },
+        };
+
+        const courseContext = new InteractionContext({
+            name: contextName,
+            type: contextType,
+            chartNodeData: this.prepareNode(nodeConfig),
+        });
+
+        // Add each interaction to the appropriate user's interaction type count
+        courseContext.addUserInteractions(courseInteractions);
+
+        // Add a node for every user in the course interaction context
+        for (const userInContext of courseContext) {
+            courseContext.chartNodeData.children.push(this.prepareUserNode(userInContext));
+        }
+
+        return courseContext;
+    }
+
+    /**
+     * Create an InteractionContext for the given learningGroup
+     */
+    getLearningGroupContext(learningGroup) {
+        const contextType = learningGroup.learning_group_prefix;
+        const contextName = learningGroup.channel_name;
+
+        // Get user's interactions in this learning group's context
+        const lgInteractions = this.props.userInteractions.filter((interaction) => {
+            return interaction.channel_name === contextName;
+        });
+
+        const interactionCount = lgInteractions.length;
+
+        // Create node configuration object for this learning group's node
+        const nodeConfig = {
+            nodeLabel: this.getNodeLabel({
+                label: contextType,
+                interactionCount,
+            }),
+            color: this.getNodeColor({nodeContext: contextType}),
+            nodeWidth: graphConfigurationValues.interactionContextNodes.nodeWidth,
+            config: {
+                tooltipHTML: this.getContextTooltip({
+                    contextName,
+                    interactionCount,
+                }),
+            },
+            nodeInfo: {
+                contextType,
+                contextName,
+            },
+        };
+
+        const lgInteractionContext = new InteractionContext({
+            name: contextName,
+            type: contextType,
+            chartNodeData: this.prepareNode(nodeConfig),
+        });
+
+        // Ensure that a UserInContext record exists for all members of this learning group
+        // (we want a record even if there are no interactions w/ the user so we can display
+        // a node w/ 0 interactions in the graph)
+        if (learningGroup.members) {
+            // members is a comma delimited list of usernames
+            lgInteractionContext.addUsers(learningGroup.members.split(','));
+        }
+
+        // Add each interaction to the appropriate user's interaction type count
+        lgInteractionContext.addUserInteractions(lgInteractions);
+
+        // Add a node for every user in the course interaction context
+        for (const userInContext of lgInteractionContext) {
+            lgInteractionContext.chartNodeData.children.push(this.prepareUserNode(userInContext));
+        }
+
+        return lgInteractionContext;
+    }
+
+    /**
+     * Generate and return an interaction context object for each learning group
+     *     1. Loop over all learning groups and generate a node config and InteractionContext for each learning group
+     *     3. Loop over all interactions that occurred in each learning group and group them into
+     *        UserInContext objects for each user, counting the interaction types respectively
+     *     4. Loop over members of this group, and if you haven't already added a UserInContext object
+     *        for a user, which indicates you haven't interacted with them in this context, add a UserInContext for them
+     *
+     * @returns {Object<InteractionContext>} containing an InteractionContext object for each
+     *      learning group and its users, keys are channel slug names
+     */
+    getLearningGroupContexts() {
+        const learningGroupContexts = {};
+
+        for (const learningGroup of this.props.userLearningGroups) {
+            const lgInteractionContext = this.getLearningGroupContext(learningGroup);
+
+            // Add the interaction context to the map of learning group contexts indexed by channel name
+            learningGroupContexts[learningGroup.channel_name] = lgInteractionContext;
+        }
+
+        return learningGroupContexts;
+    }
+
+    /**
+     * Prepares the 'You' node
+     *
+     * @returns {Object} containing a node configuration for the 'You' node
+     */
+    getYouNode() {
+        return {
+            nodeLabel: this.getNodeLabel({label: 'You', interactionCount: 0}),
+            nodeWidth: graphConfigurationValues.youNode.nodeWidth,
+            config: {
+                outerCircle: {
+                    stroke: nodeColors.you.backgroundColor,
+                    strokeWidth: graphConfigurationValues.outerCircleStrokeWidth,
+                },
+                circle: {
+                    fill: nodeColors.you.backgroundColor,
+                    stroke: nodeColors.you.backgroundColor,
+                },
+                label: graphConfigurationValues.youNode.nodeLabel,
+            },
+            children: [],
+            nodeInfo: {
+                contextType: 'you',
+            },
+        };
+    }
+
+    /**
+     * Prepares the tooltip for an interaction context's node
+     *
+     * @param {string} contextName - the channel slug name for a learning group, or 'course'
+     * @param {number} interactionCount - the total interactions in this context that the current user took part in
+     *
+     * @returns {string} containing html for the tooltip
+     */
+    getContextTooltip({contextName, interactionCount}) {
+        return `<div style='font-weight:bold;'>${contextName}: ${interactionCount}</div>`;
+    }
+
+    /**
+     * Prepares the tooltip for a user's node
+     *
+     * @param {UserInContext} user - containing interaction counts for this user's node in this context
+     *
+     * @returns {string} containing html for the tooltip
+     */
+    getUserTooltip(user) {
+        const usernameDiv = `<div style='font-weight:bold;'>@${user.username}</div>`;
+        const reactionsDiv = `<div>Reactions: ${user.getInteractionCount('Reaction')}</div>`;
+        const repliesDiv = `<div>Replies: ${user.getInteractionCount('Reply')}</div>`;
+        const mentionsDiv = `<div>Mentions: ${user.getInteractionCount('Mention')}</div>`;
+        let dmsDiv = '';
+        if (user.contextType === 'course') {
+            dmsDiv = `<div>Direct Messages: ${user.getInteractionCount('DirectMessage')}</div>`;
+        }
+
+        const html =
+            '<div style=\'text-align: center;\'>' +
+                `${usernameDiv}${reactionsDiv}${repliesDiv}${mentionsDiv}${dmsDiv}` +
+            '</div>';
+
+        return html;
+    }
+
+    /**
+     * Create the data object for a user node in the chart.
+     */
+    prepareUserNode(userInContext) {
+        // Configuration for this user's node
+        const contextType = userInContext.contextType;
+        const interactionCount = userInContext.getInteractionAggregate();
+        let fillOpacity;
+        let strokeOpacity;
+        if (contextType !== 'course' && interactionCount === 0) {
+            strokeOpacity = graphConfigurationValues.userNodes.uncontactedLinkOpacity;
+            fillOpacity = graphConfigurationValues.userNodes.uncontactedNodeOpacity;
+        }
+
+        const userNodeConfig = {
+            nodeLabel: this.getNodeLabel({interactionCount}),
+            color: this.getNodeColor({nodeContext: contextType}),
+            nodeWidth: graphConfigurationValues.userNodes.nodeWidth,
+            config: {
+                tooltipHTML: this.getUserTooltip(userInContext),
+            },
+            configLink: {
+                strokeOpacity,
+            },
+            configCircle: {
+                fillOpacity,
+            },
+            nodeInfo: {
+                contextType,
+            },
+        };
+
+        return this.prepareNode(userNodeConfig);
+    }
+
+    /**
+     * Prepares the configuration object for a node
+     *
+     * @param {string} nodeLabel - text to be displayed on the node
+     * @param {Object} color - containing backgroundColor and fontColor properties for this node
+     * @param {number} nodeWidth - the relative width of this node
+     * @param {Object} config - containing node configuration settings specific to this node
+     * @param {Object} configLink - containing link configuration settings specific to this node
+     * @param {Object} configCircle - containing circle configuration settings specific to this node (ex. opacity)
+     * @param {Object} nodeInfo - containing information used to identify this node
+     *
+     * @returns {Object} containing the node configuration
+     */
+    prepareNode({nodeLabel, color, nodeWidth, config, configLink, configCircle, nodeInfo}) {
+        const node = {
+            nodeInfo,
+            nodeLabel,
+            nodeWidth,
+            config: {
+                ...config,
+                label: {
+                    valign: 'auto',
+                    fontSize: '14',
+                    fontWeight: 'bold',
+                    fill: color.fontColor,
+                    truncate: true,
+                },
+                outerCircle: {
+                    stroke: color.backgroundColor,
+                    strokeWidth: graphConfigurationValues.outerCircleStrokeWidth,
+                },
+                circle: {
+                    ...configCircle,
+                    fill: color.backgroundColor,
+                    stroke: color.backgroundColor,
+                },
+            },
+            configLink: {
+                ...configLink,
+                fill: color.backgroundColor,
+                stroke: color.backgroundColor,
+            },
+            configTooltip: {
+                background: {
+                    fill: color.backgroundColor,
+                },
+                label: {
+                    fontSize: '16',
+                    fill: color.fontColor,
+                },
+            },
+            children: [],
+        };
+
+        return node;
+    }
+
+    /**
+     * Prepares the label for a node
+     *
+     * @param {string} label - some text to show on the node
+     * @param {number} interactionCount - the aggregate interaction count for this node
+     *
+     * @returns {string} label for a node
+     */
+    getNodeLabel({label, interactionCount}) {
+        return `${label ? `${label} \n ` : ''}${interactionCount}`;
+    }
+
+    /**
+     * Get the color to be used for a node, node link, or node label
+     *
+     * @param {string} nodeContext
+     *      the interaction context in which to fetch a color for
+     *
+     * @param {string | undefined} colorUsage
+     *      indicating the specific usage for this color request (enum('backgroundColor','fontColor'))
+     *
+     * @returns {{backgroundColor: string, fontColor: string} | string} a color object
+     *      with properties backgroundColor, and fontColor, or the value of one of those properties
+     */
+    getNodeColor({nodeContext, colorUsage}) {
+        let nodeColor;
+
+        /* eslint-disable indent, no-negated-condition */
+        switch (nodeContext) {
+            case 'you':
+                nodeColor = nodeColors.you;
+                break;
+
+            case 'course':
+                nodeColor = nodeColors.course;
+                break;
+
+            default: {
+                let indexOfLearningGroup = this.sortedLearningGroupTypes.findIndex((t) => t.prefix === nodeContext);
+                indexOfLearningGroup = indexOfLearningGroup !== -1 ? indexOfLearningGroup : 0;
+                nodeColor = getColorForLearningGroup(indexOfLearningGroup);
+                break;
+            }
+        }
+        /* eslint-enable indent, no-negated-condition */
+
+        if (colorUsage) {
+            return nodeColor[colorUsage];
+        }
+
+        return nodeColor;
+    }
+
+    /**
+     * amchart adapter function to return the color for a node.
+     * (will need to have 'this' bound to be passed as an adapter handler)
+     *
+     * Setting up the 'stroke' adapter with this handler  'stroke' adapterSets the colors for the node links
+     * Unfortunately this seems to be the only way to set the colors for
+     * node links.
+     * Uses the nodeInfo.contextType property of the data bound to the node
+     * to determine the color to return.
+     */
+    getChartNodeColor(stroke, node) {
+        // Node isn't setup yet, return
+        if (!node.dataItem.dataContext) {
+            return false;
+        }
+
+        const nodeInfo = node.dataItem.dataContext.nodeInfo;
+
+        const colorConfig = {
+            nodeContext: nodeInfo.contextType,
+            colorUsage: 'backgroundColor',
+        };
+
+        return am4core.color(this.getNodeColor(colorConfig));
+    }
+}
+
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    CourseConnectionsView,
+};

--- a/components/dashboard/components/CourseConnections/index.js
+++ b/components/dashboard/components/CourseConnections/index.js
@@ -1,0 +1,43 @@
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {connect} from 'react-redux';
+
+import {RequestStatus} from 'mattermost-redux/constants';
+import {Datasets} from 'mattermost-redux/constants/user_analytics';
+import {getCurrentTeamId} from 'mattermost-redux/selectors/entities/teams';
+import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
+import {getUserAnalytics} from 'mattermost-redux/actions/users';
+
+import {CourseConnectionsView} from './CourseConnectionsView';
+
+function isRequestLoaded(req) {
+    return Boolean(req && req.status === RequestStatus.SUCCESS);
+}
+
+const mapStateToProps = (state) => ({
+    isUserInteractionsLoaded: isRequestLoaded(state.requests.users.getUserAnalytics[Datasets.USER_INTERACTIONS]),
+    userInteractions: state.entities.users.analytics[Datasets.USER_INTERACTIONS],
+    userLearningGroups: state.entities.users.analytics[Datasets.USER_LEARNING_GROUPS],
+    learningGroupTypes: state.entities.users.analytics[Datasets.LEARNING_GROUP_TYPES],
+    currentUser: getCurrentUser(state),
+    currentTeamId: getCurrentTeamId(state),
+});
+
+const mapDispatchToProps = (dispatch) => ({
+    fetchUserInteractions: (userId, teamId) => {
+        dispatch(getUserAnalytics(userId, teamId, Datasets.USER_INTERACTIONS));
+    },
+});
+
+const CourseConnections = connect(
+    mapStateToProps,
+    mapDispatchToProps,
+)(CourseConnectionsView);
+
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    CourseConnections,
+};

--- a/components/dashboard/components/MeetingViz.jsx
+++ b/components/dashboard/components/MeetingViz.jsx
@@ -2,31 +2,31 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import sizeMe from 'react-sizeme';
 import styled from 'styled-components';
 import Waypoint from 'react-waypoint';
 import moment from 'moment';
 import _ from 'underscore';
-import PropTypes from 'prop-types';
 
 import {
     loadMeetingData,
-} from '../../../actions/views/dashboard';
+} from 'actions/views/dashboard';
 
-import {logger} from '../../../utils/riff';
+import {logger} from 'utils/riff';
 
 import {getIsRhsOpen} from 'selectors/rhs';
 
 import TurnChart from './TurnChart';
 import InfluenceChart from './InfluenceChart';
 import TimelineChart from './TimelineChart';
-const SpaceBetweeen = styled.div.attrs({
-    className: 'space-between',
+
+const MeetingHeader = styled.h3.attrs({
+    className: 'meeting-header',
 })`
-    display: flex;
-    justify-content: space-between;
-    width: 320px;
+    font-weight: bold;
+    padding-bottom: .5rem;
 `;
 
 const getMeetingIndex = (meetings, meetingId) => {
@@ -73,23 +73,19 @@ const mapDispatchToProps = (dispatch) => ({
 
 const Header = (props) => {
     logger.debug('HEADER props:', props);
-    const meetingDate = moment(props.meeting.startTime).format('ha MMM Do');
+    const meetingDate = moment(props.meeting.startTime).format('M/D/Y, h:mm A');
     return (
         <div
             className=''
             style={{
                 paddingBottom: '2rem',
-                paddingTop: '1rem',
-                paddingLeft: '1rem',
+                paddingTop: '2rem',
             }}
         >
-            <h3>{`Meeting at: ${meetingDate}`} </h3>
-            <SpaceBetweeen>
-                <span>{`Attendees: ${props.processedUtterances.length}`}</span>
-            </SpaceBetweeen>
-            <SpaceBetweeen>
-                <span>{`Duration: ${props.selectedMeetingDuration}`}</span>
-            </SpaceBetweeen>
+            <MeetingHeader>{'Meeting Metrics'}</MeetingHeader>
+            <span>{meetingDate}</span>
+            <span>{`, Attendees: ${props.processedUtterances.length}, `}</span>
+            <span>{`Duration: ${props.selectedMeetingDuration}`}</span>
             <div className='column is-half has-text-left'/>
         </div>
     );

--- a/components/dashboard/components/SectionHeader.jsx
+++ b/components/dashboard/components/SectionHeader.jsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Title = styled.div`
+font-size: ${(props) => {
+        return props.mainHeader ? '40px' : '32px';
+    }};
+font-weight: bold;
+`;
+
+const Desc = styled.div`
+font-size: ${(props) => {
+        return props.mainHeader ? '20px' : '16px';
+    }};
+`;
+
+const Hr = styled.hr`
+height: 3px;
+background: #4a4a4a;
+`;
+
+/* ******************************************************************************
+ * SectionHeader                                                           */ /**
+ *
+ * React component to render a title and description for a section in the
+ * dashboard.
+ *
+ ********************************************************************************/
+class SectionHeader extends React.Component {
+    static propTypes = {
+
+        /** A title for this dashboard section */
+        title: PropTypes.string.isRequired,
+
+        /** A multi-line description for this dashboard section */
+        desc: PropTypes.string.isRequired,
+
+        /** Denotes whether to increase size of text and place horizontal line at bottom */
+        mainHeader: PropTypes.bool,
+    };
+
+    render() {
+        return (
+            <div>
+                <Title mainHeader={this.props.mainHeader}>{this.props.title}</Title>
+                <Desc mainHeader={this.props.mainHeader}>{this.props.desc}</Desc>
+                {this.props.mainHeader && <Hr/>}
+            </div>
+        );
+    }
+}
+
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    SectionHeader,
+};

--- a/components/dashboard/index.js
+++ b/components/dashboard/index.js
@@ -1,47 +1,27 @@
 // Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {withRouter} from 'react-router-dom';
 import {connect} from 'react-redux';
 
-import $ from 'jquery';
-import moment from 'moment';
-import lifecycle from 'react-pure-lifecycle';
 import {getCurrentUser} from 'mattermost-redux/selectors/entities/users';
 
 import {
     loadMoreMeetings,
     loadRecentMeetings,
-    selectMeeting,
-    loadMeetingData,
 } from 'actions/views/dashboard';
 import * as RiffServerActionCreators from 'actions/views/riff';
 import {logger} from 'utils/riff';
-import * as UserAgent from 'utils/user_agent.jsx';
 
-import DashboardView from './DashboardView';
+import {DashboardView} from './DashboardView';
 
 const mapStateToProps = (state) => {
-    logger.debug('Dashboard.mapStateToProps: state:', state);
-    const {lti, dashboard, riff} = state.views;
-    const riffState = {...lti, ...dashboard, ...riff};
     return {
         user: getCurrentUser(state),
-        riff,
-        riffAuthToken: riffState.authToken,
-        fetchMeetingsStatus: riffState.fetchMeetingsStatus,
-        fetchMeetingsMessage: riffState.fetchMeetingsMessage,
-        meetings: riffState.meetings,
-        numMeetings: riffState.numMeetings,
-        lastFetched: riffState.lastFetched,
-        shouldFetch: riffState.shouldFetch,
-        selectedMeeting: riffState.selectedMeeting || null,
-        processedUtterances: riffState.processedUtterances,
-        statsStatus: riffState.statsStatus,
-        processedNetwork: riffState.networkData,
-        processedTimeline: riffState.timelineData,
-        loadingError: riffState.loadingError,
-        numMeetingsToDisplay: riffState.numMeetingsToDisplay,
+        riffAuthToken: state.views.riff.authToken,
+        meetings: state.views.dashboard.meetings,
+        shouldFetch: state.views.dashboard.shouldFetch,
+        loadingError: state.views.dashboard.loadingError,
+        numMeetingsToDisplay: state.views.dashboard.numMeetingsToDisplay,
     };
 };
 
@@ -52,33 +32,11 @@ const mapDispatchToProps = (dispatch) => ({
     loadRecentMeetings: (uid) => {
         dispatch(loadRecentMeetings(uid));
     },
-    handleRefreshClick: (event, uid) => {
-        dispatch(loadRecentMeetings(uid));
-    },
-    handleMeetingClick: (event, uid, meeting) => {
-        event.preventDefault();
-
-        /// TODO: Why do we want 2 distinct actions to select the meeting and to load the meeting data? -mjl 2018-09-05
-        dispatch(selectMeeting(meeting));
-        dispatch(loadMeetingData(uid, meeting._id));
-    },
     authenticateRiff: () => {
         logger.debug('Dashboard.authenticateRiff: attempt data-server auth');
         dispatch(RiffServerActionCreators.attemptRiffAuthenticate());
     },
 });
-
-const formatMeetingDuration = (meeting) => {
-    if (!meeting) {
-        return '';
-    }
-
-    // support showing data on in progress meeting by giving them a fake end time of now
-    const startDate = new Date(meeting.startTime);
-    const endDate = meeting.endTime ? new Date(meeting.endTime) : new Date();
-    const diff = moment(endDate).diff(moment(startDate), 'minutes');
-    return `${diff} minutes`;
-};
 
 const mapMergeProps = (stateProps, dispatchProps, ownProps) => {
     logger.debug('Dashboard.mapMergeProps: user:', stateProps.user);
@@ -86,9 +44,6 @@ const mapMergeProps = (stateProps, dispatchProps, ownProps) => {
         ...stateProps,
         ...dispatchProps,
         ...ownProps,
-        selectedMeetingDuration: formatMeetingDuration(
-            stateProps.meetings[0]
-        ),
 
         // TODO: Load is the wrong terminalogy here, and maybe also in more of these properties as well.
         //       Consider renaming this to maybeDisplayNextMeeting -mjl 2019-04-26
@@ -109,48 +64,14 @@ const mapMergeProps = (stateProps, dispatchProps, ownProps) => {
     };
 };
 
-const componentDidUpdate = (props) => {
-    if (props.riffAuthToken && props.shouldFetch) {
-        props.loadRecentMeetings(props.user.id);
-    }
+const Dashboard = connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    mapMergeProps)(DashboardView);
+
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    Dashboard,
 };
-
-const componentDidMount = (props) => {
-    if (props.riffAuthToken) {
-        props.loadRecentMeetings(props.user.id);
-    }
-
-    $('body').addClass('app__body');
-
-    // IE Detection
-    if (UserAgent.isInternetExplorer() || UserAgent.isEdge()) {
-        $('body').addClass('browser--IE');
-    }
-};
-
-const componentWillMount = (props) => {
-    logger.debug('Dashboard.componentWillMount: user:', props.user);
-    if (!props.riff.authToken) {
-        props.authenticateRiff();
-    }
-};
-
-// componentWillUnmount = () => {
-//     $('body').removeClass('app__body');
-// }
-
-const methods = {
-    componentDidUpdate,
-    componentDidMount,
-    componentWillMount,
-};
-
-const Dashboard = lifecycle(methods)(DashboardView);
-
-export default withRouter(
-    connect(
-        mapStateToProps,
-        mapDispatchToProps,
-        mapMergeProps
-    )(Dashboard)
-);

--- a/components/page_layout/Page/page.jsx
+++ b/components/page_layout/Page/page.jsx
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import {Route, Switch} from 'react-router-dom';
 import classNames from 'classnames';
 
-import Dashboard from 'components/dashboard';
+import {Dashboard} from 'components/dashboard';
 import Navbar from 'components/navbar';
 
 export default class Page extends React.PureComponent {

--- a/components/sidebar/sidebar.jsx
+++ b/components/sidebar/sidebar.jsx
@@ -568,7 +568,7 @@ export default class Sidebar extends React.PureComponent {
                     </span>
                     <FormattedMessage
                         id='sidebar.dashboard'
-                        defaultMessage='Riff Stats'
+                        defaultMessage='Riff Metrics'
                     />
                 </button>
             </li>

--- a/components/webrtc_view_bulma/RenderVideos.jsx
+++ b/components/webrtc_view_bulma/RenderVideos.jsx
@@ -207,7 +207,7 @@ class RenderVideos extends React.Component {
                         >
                             <div className='column is-vcentered has-text-centered'>
                                 <h1>{'Nobody else here...'}</h1>
-                                <ScaleLoader color={Colors.lightroyal}/>
+                                <ScaleLoader color={Colors.lightRoyal}/>
                             </div>
                         </div>
 

--- a/components/webrtc_view_bulma/WebrtcSidebar.jsx
+++ b/components/webrtc_view_bulma/WebrtcSidebar.jsx
@@ -173,7 +173,7 @@ class AudioStatusBar extends React.PureComponent {
 
             return (
                 <div style={{paddingBottom: '20px'}}>
-                    <MaterialIcon icon='warning' color={Colors.brightred}/>
+                    <MaterialIcon icon='warning' color={Colors.brightRed}/>
                     <div>
                         {text}
                     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,25 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@amcharts/amcharts4": {
+      "version": "4.5.14",
+      "resolved": "https://registry.npmjs.org/@amcharts/amcharts4/-/amcharts4-4.5.14.tgz",
+      "integrity": "sha512-yrlE9zko9/Ogj+B/ej70QdCUGydb42EETwqzHEnHTPdAyl1hy24c0AlbYcnUINa2e2NbCiWgvlHbHq4Yo8kdZA==",
+      "requires": {
+        "@types/regression": "^2.0.0",
+        "canvg": "^2.0.0",
+        "css-element-queries": "^1.0.5",
+        "d3-force": "^2.0.1",
+        "d3-geo": "^1.11.3",
+        "d3-geo-projection": "^2.6.0",
+        "fabric": "3.3.2-browser",
+        "pdfmake": "^0.1.36",
+        "polylabel": "^1.0.2",
+        "regression": "^2.0.1",
+        "tslib": "^1.9.3",
+        "xlsx": "^0.12.8"
+      }
+    },
     "@babel/code-frame": {
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
@@ -268,6 +287,11 @@
       "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
+    },
+    "@types/regression": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/regression/-/regression-2.0.0.tgz",
+      "integrity": "sha512-Ch2FD53M1HpFLL6zSTc/sfuyqQcIPy+/PV3xFT6QYtk9EOiMI29XOYmLNxBb1Y0lfMOR/NNa86J1gRc/1jGLyw=="
     },
     "@webassemblyjs/ast": {
       "version": "1.5.13",
@@ -578,6 +602,28 @@
       "integrity": "sha512-tiNTrP1MP0QrChmD2DdupCr6HWSFeKVw5d/dHTu4Y7rkAkRhU/Dt7dphAfIUyxtHpl/eBVip5uTNSpQJHylpAw==",
       "dev": true
     },
+    "acorn-node": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.8.2.tgz",
+      "integrity": "sha512-8mt+fslDufLYntIoPAaIMUe/lrbrehIiwmR3t2k9LljIzoigEPF27eLk2hy8zSGzmR/ogr7zbRKINMo1u0yh5A==",
+      "requires": {
+        "acorn": "^7.0.0",
+        "acorn-walk": "^7.0.0",
+        "xtend": "^4.0.2"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
+          "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ=="
+        },
+        "acorn-walk": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.0.0.tgz",
+          "integrity": "sha512-7Bv1We7ZGuU79zZbb6rRqcpxo3OY+zrdtloZWoyD8fmGX+FeXRjE+iuGkZjSXLVovLzrsvMGMy0EkwA0E0umxg=="
+        }
+      }
+    },
     "acorn-walk": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
@@ -588,6 +634,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/add-px-to-style/-/add-px-to-style-1.0.0.tgz",
       "integrity": "sha1-0ME1RB+oAUqBN5BFMQlvZ/KPJjo="
+    },
+    "adler-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.2.0.tgz",
+      "integrity": "sha1-aj5r8KY5ALoVZSgIyxXGgT0aXyU=",
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      }
     },
     "after": {
       "version": "0.8.2",
@@ -666,8 +721,7 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-      "dev": true
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-escapes": {
       "version": "4.2.1",
@@ -848,6 +902,11 @@
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
       "dev": true
     },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU="
+    },
     "array-includes": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
@@ -979,6 +1038,53 @@
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
       "dev": true
+    },
+    "ast-transform": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/ast-transform/-/ast-transform-0.0.0.tgz",
+      "integrity": "sha1-dJRAWIh9goPhidlUYAlHvJj+AGI=",
+      "requires": {
+        "escodegen": "~1.2.0",
+        "esprima": "~1.0.4",
+        "through": "~2.3.4"
+      },
+      "dependencies": {
+        "escodegen": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.2.0.tgz",
+          "integrity": "sha1-Cd55Z3kcyVi3+Jot220jRRrzJ+E=",
+          "requires": {
+            "esprima": "~1.0.4",
+            "estraverse": "~1.5.0",
+            "esutils": "~1.0.0",
+            "source-map": "~0.1.30"
+          }
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz",
+          "integrity": "sha1-n1V+CPw7TSbs6d00+Pv0drYlha0="
+        },
+        "estraverse": {
+          "version": "1.5.1",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.5.1.tgz",
+          "integrity": "sha1-hno+jlip+EYYr7bC3bzZFrfLr3E="
+        },
+        "esutils": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.0.0.tgz",
+          "integrity": "sha1-gVHTWOIMisx/t0XnRywAJf5JZXA="
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "optional": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
     },
     "ast-types": {
       "version": "0.9.6",
@@ -2391,8 +2497,7 @@
     "base64-js": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-      "dev": true
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
     },
     "batch-processor": {
       "version": "1.0.0",
@@ -2771,11 +2876,30 @@
         "repeat-element": "^1.1.2"
       }
     },
+    "brfs": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brfs/-/brfs-2.0.2.tgz",
+      "integrity": "sha512-IrFjVtwu4eTJZyu8w/V2gxU7iLTtcHih67sgEdzrhjLBMHp2uYefUBfdM4k2UvcuWMgV7PQDZHSLeNWnLFKWVQ==",
+      "requires": {
+        "quote-stream": "^1.0.1",
+        "resolve": "^1.1.5",
+        "static-module": "^3.0.2",
+        "through2": "^2.0.0"
+      }
+    },
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
+    },
+    "brotli": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/brotli/-/brotli-1.3.2.tgz",
+      "integrity": "sha1-UlqcrU/LqWR119OI9q7LE+7VL0Y=",
+      "requires": {
+        "base64-js": "^1.1.2"
+      }
     },
     "browser-process-hrtime": {
       "version": "0.1.3",
@@ -2787,7 +2911,6 @@
       "version": "1.11.3",
       "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.3.tgz",
       "integrity": "sha512-exDi1BYWB/6raKHmDTCicQfTkqwN5fioMFV4j8BsfMU4R2DK/QfZfK7kOVkmWCNANf0snkBzqGqAJBao9gZMdQ==",
-      "dev": true,
       "requires": {
         "resolve": "1.1.7"
       },
@@ -2795,8 +2918,7 @@
         "resolve": {
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
+          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
         }
       }
     },
@@ -2841,6 +2963,23 @@
         "des.js": "^1.0.0",
         "inherits": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "browserify-optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browserify-optional/-/browserify-optional-1.0.1.tgz",
+      "integrity": "sha1-HhNyLP3g2F8SFnbCpyztUzoBiGk=",
+      "requires": {
+        "ast-transform": "0.0.0",
+        "ast-types": "^0.7.0",
+        "browser-resolve": "^1.8.1"
+      },
+      "dependencies": {
+        "ast-types": {
+          "version": "0.7.8",
+          "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.7.8.tgz",
+          "integrity": "sha1-kC0uDWDQcb3NRtwRXhgJ7RHBOKk="
+        }
       }
     },
     "browserify-rsa": {
@@ -2940,8 +3079,7 @@
     "buffer-equal": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
-      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs=",
-      "dev": true
+      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
     },
     "buffer-fill": {
       "version": "1.0.0",
@@ -2952,8 +3090,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -3120,6 +3257,15 @@
       "integrity": "sha512-vrMcvSuMz16YY6GSVZ0dWDTJP8jqk3iFQ/Aq5iqblPwxSVVZI+zxDyTX0VPqtQsDnfdrBDcsmhgTEOh5R8Lbpw==",
       "dev": true
     },
+    "canvg": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-2.0.0.tgz",
+      "integrity": "sha512-PiKa+sjzzAv8HONsBaJZRhZ3eCM5uJkpFgF0rSzcamOrdXdls81ukjNxtz7JYyxucj6WpIkZwk9j7Jku0+ivqQ==",
+      "requires": {
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0"
+      }
+    },
     "capture-exit": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-1.2.0.tgz",
@@ -3151,6 +3297,15 @@
         "isurl": "^1.0.0-alpha5",
         "tunnel-agent": "^0.6.0",
         "url-to-options": "^1.0.1"
+      }
+    },
+    "cfb": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.0.8.tgz",
+      "integrity": "sha1-d/ITST1pfXVP2cD1UR6rWtctAs8=",
+      "requires": {
+        "commander": "^2.14.1",
+        "printj": "~1.1.2"
       }
     },
     "chai-nightwatch": {
@@ -3471,6 +3626,22 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
+    "codepage": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.13.1.tgz",
+      "integrity": "sha512-KnY6cQlgkfBjplnQkLk3M5KEfAKa7i9SMqXp+bMuy2/bgYovvU4LDAQvkMaoScwhvozA9VUtgnbS4Z8f7zVA8w==",
+      "requires": {
+        "commander": "~2.14.1",
+        "exit-on-epipe": "~1.0.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.14.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.14.1.tgz",
+          "integrity": "sha512-+YR16o3rK53SmWHU3rEM3tPAh2rwb1yPcQX5irVn7mb0gXbwuCCrnkbV5+PBfETdfg1vui07nM6PCG1zndcjQw=="
+        }
+      }
+    },
     "coffee-loader": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/coffee-loader/-/coffee-loader-0.9.0.tgz",
@@ -3517,8 +3688,7 @@
     "commander": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -3564,7 +3734,6 @@
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -3575,14 +3744,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -3596,14 +3763,12 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -3779,6 +3944,15 @@
         "parse-json": "^4.0.0"
       }
     },
+    "crc-32": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.0.tgz",
+      "integrity": "sha512-1uBwHxF+Y/4yF5G48fwnKq6QsIXheor3ZLPT80yGBV1oEUwpPojlEhQbWKVw1VwcTQyMGHK1/XMmTjmlsmTTGA==",
+      "requires": {
+        "exit-on-epipe": "~1.0.1",
+        "printj": "~1.1.0"
+      }
+    },
     "create-ecdh": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
@@ -3888,6 +4062,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "3.1.9-1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.9-1.tgz",
+      "integrity": "sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg="
+    },
     "css-color-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
@@ -3898,6 +4077,11 @@
       "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
+    },
+    "css-element-queries": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/css-element-queries/-/css-element-queries-1.2.1.tgz",
+      "integrity": "sha512-hiI1tSzf+U/gE13qhfwnCvN90Ay0THnE+mT3pjN/c/mvFmEUHZVNrvMJrrkw2ppOzkl69FdgH2ZGZENYQUaN2A=="
     },
     "css-loader": {
       "version": "1.0.0",
@@ -4078,6 +4262,15 @@
       "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA=",
       "dev": true
     },
+    "d": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
+      "requires": {
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
+      }
+    },
     "d3-array": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
@@ -4108,10 +4301,39 @@
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-1.0.5.tgz",
       "integrity": "sha512-Ct1O//ly5y5lFM9YTdu+ygq7LleSgSE4oj7vUt9tPLHUi8VCV7QoizGpdWRWAwCO9LdYzIrQDg97+hGVdsSGPQ=="
     },
+    "d3-force": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-2.0.1.tgz",
+      "integrity": "sha512-zh73/N6+MElRojiUG7vmn+3vltaKon7iD5vB/7r9nUaBeftXMzRo5IWEG63DLBCto4/8vr9i3m9lwr1OTJNiCg==",
+      "requires": {
+        "d3-dispatch": "1",
+        "d3-quadtree": "1",
+        "d3-timer": "1"
+      }
+    },
     "d3-format": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.3.2.tgz",
       "integrity": "sha512-Z18Dprj96ExragQ0DeGi+SYPQ7pPfRMtUXtsg/ChVIKNBCzjO8XYJvRTC1usblx52lqge56V5ect+frYTQc8WQ=="
+    },
+    "d3-geo": {
+      "version": "1.11.6",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.11.6.tgz",
+      "integrity": "sha512-z0J8InXR9e9wcgNtmVnPTj0TU8nhYT6lD/ak9may2PdKqXIeHUr8UbFLoCtrPYNsjv6YaLvSDQVl578k6nm7GA==",
+      "requires": {
+        "d3-array": "1"
+      }
+    },
+    "d3-geo-projection": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.7.0.tgz",
+      "integrity": "sha512-G8C/8gvUQVwuLloW88d/NGbyh5CLONowQzU6gB7cczfGbSjMrQHFbaCqipWUqUWaBdqpyfTlLE3GPGy0RMpKYw==",
+      "requires": {
+        "commander": "2",
+        "d3-array": "1",
+        "d3-geo": "^1.10.0",
+        "resolve": "^1.1.10"
+      }
     },
     "d3-interpolate": {
       "version": "1.3.2",
@@ -4120,6 +4342,11 @@
       "requires": {
         "d3-color": "1"
       }
+    },
+    "d3-quadtree": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.6.tgz",
+      "integrity": "sha512-NUgeo9G+ENQCQ1LsRr2qJg3MQ4DJvxcDNCiohdJGHt5gRhBW6orIB5m5FJ9kK3HNL8g9F4ERVoBzcEwQBfXWVA=="
     },
     "d3-scale": {
       "version": "2.2.2",
@@ -4377,8 +4604,7 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "default-require-extensions": {
       "version": "1.0.0",
@@ -4515,6 +4741,11 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
       "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=",
       "dev": true
+    },
+    "dfa": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/dfa/-/dfa-1.2.0.tgz",
+      "integrity": "sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q=="
     },
     "diff": {
       "version": "3.5.0",
@@ -4710,6 +4941,48 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
+        }
+      }
+    },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "^2.0.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
@@ -5029,11 +5302,65 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es5-ext": {
+      "version": "0.10.50",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.50.tgz",
+      "integrity": "sha512-KMzZTPBkeQV/JcSQhI5/z6d9VWJ3EnQ194USTUwIYZ2ZbpN8+SGXQKt1h68EX44+qt+Fzr8DO17vnxrw7c3agw==",
+      "requires": {
+        "es6-iterator": "~2.0.3",
+        "es6-symbol": "~3.1.1",
+        "next-tick": "^1.0.0"
+      }
+    },
+    "es6-iterator": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "^0.10.35",
+        "es6-symbol": "^3.1.1"
+      }
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
     "es6-promise": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
       "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
       "dev": true
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "~0.3.5"
+      }
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "es6-templates": {
       "version": "0.2.3",
@@ -5054,7 +5381,6 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
       "integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
-      "dev": true,
       "requires": {
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
@@ -5066,14 +5392,12 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
-          "dev": true
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
         },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true,
           "optional": true
         }
       }
@@ -5462,13 +5786,26 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+    },
+    "estree-is-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/estree-is-function/-/estree-is-function-1.0.0.tgz",
+      "integrity": "sha512-nSCWn1jkSq2QAtkaVLJZY2ezwcFO161HVc174zL1KPW3RJ+O6C3eJb8Nx7OXzvhoEv+nLgSR1g71oWUHUDTrJA=="
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1",
+        "es5-ext": "~0.10.14"
+      }
     },
     "events": {
       "version": "3.0.0",
@@ -5568,6 +5905,11 @@
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
+    },
+    "exit-on-epipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
+      "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -5690,6 +6032,29 @@
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
     },
+    "fabric": {
+      "version": "3.3.2-browser",
+      "resolved": "https://registry.npmjs.org/fabric/-/fabric-3.3.2-browser.tgz",
+      "integrity": "sha512-gyOQrvDLAQGifFK9kSZUW5E6yo8nSmbDA4vEo2Tk5oWXsnNb6e94ud5S9lI66ALW9eArEI51YOnzBdaXZHMbtA=="
+    },
+    "falafel": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
+      "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
+      "requires": {
+        "acorn": "^5.0.0",
+        "foreach": "^2.0.5",
+        "isarray": "0.0.1",
+        "object-keys": "^1.0.6"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.3",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.3.tgz",
+          "integrity": "sha512-T/zvzYRfbVojPWahDsE5evJdHb3oJoQfFbsrKM7w5Zcs++Tr257tia3BmMP8XYVjp1S9RZXQMh7gao96BlqZOw=="
+        }
+      }
+    },
     "fast-deep-equal": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
@@ -5703,8 +6068,7 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fastclick": {
       "version": "1.0.6",
@@ -6023,6 +6387,137 @@
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
       "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
     },
+    "fontkit": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/fontkit/-/fontkit-1.8.0.tgz",
+      "integrity": "sha512-EFDRCca7khfQWYu1iFhsqeABpi87f03MBdkT93ZE6YhqCdMzb5Eojb6c4dlJikGv5liuhByyzA7ikpIPTSBWbQ==",
+      "requires": {
+        "babel-runtime": "^6.11.6",
+        "brfs": "^1.4.0",
+        "brotli": "^1.2.0",
+        "browserify-optional": "^1.0.0",
+        "clone": "^1.0.1",
+        "deep-equal": "^1.0.0",
+        "dfa": "^1.0.0",
+        "restructure": "^0.5.3",
+        "tiny-inflate": "^1.0.2",
+        "unicode-properties": "^1.0.0",
+        "unicode-trie": "^0.3.0"
+      },
+      "dependencies": {
+        "brfs": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
+          "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
+          "requires": {
+            "quote-stream": "^1.0.1",
+            "resolve": "^1.1.5",
+            "static-module": "^2.2.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "clone": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
+        },
+        "escodegen": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "object-inspect": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
+          "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
+        },
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true
+        },
+        "static-module": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
+          "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
+          "requires": {
+            "concat-stream": "~1.6.0",
+            "convert-source-map": "^1.5.1",
+            "duplexer2": "~0.1.4",
+            "escodegen": "~1.9.0",
+            "falafel": "^2.1.0",
+            "has": "^1.0.1",
+            "magic-string": "^0.22.4",
+            "merge-source-map": "1.0.4",
+            "object-inspect": "~1.4.0",
+            "quote-stream": "~1.0.2",
+            "readable-stream": "~2.3.3",
+            "shallow-copy": "~0.0.1",
+            "static-eval": "^2.0.0",
+            "through2": "~2.0.3"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "unicode-trie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-0.3.1.tgz",
+          "integrity": "sha1-1nHd3YkQGgi6w3tqUWEBBgIFIIU=",
+          "requires": {
+            "pako": "^0.2.5",
+            "tiny-inflate": "^1.0.0"
+          }
+        }
+      }
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -6047,6 +6542,11 @@
         "for-in": "^1.0.1"
       }
     },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+    },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
@@ -6067,6 +6567,11 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
       "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+    },
+    "frac": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
+      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -6862,6 +7367,11 @@
       "requires": {
         "globule": "^1.0.0"
       }
+    },
+    "get-assigned-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/get-assigned-identifiers/-/get-assigned-identifiers-1.2.0.tgz",
+      "integrity": "sha512-mBBwmeGTrxEMO4pMaaf/uUEFHnYtwr8FTe8Y/mer4rcV/bye0qGm6pw1bGZFGStxC5O76c5ZAVBGnqHmOaJpdQ=="
     },
     "get-caller-file": {
       "version": "1.0.3",
@@ -9332,7 +9842,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -9344,6 +9853,23 @@
       "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
       "requires": {
         "immediate": "~3.0.5"
+      }
+    },
+    "linebreak": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.0.2.tgz",
+      "integrity": "sha512-bJwSRsJeAmaZYnkcwl5sCQNfSDAhBuXxb6L27tb+qkBRtUQSSTUa5bcgCPD6hFEkRNlpWHfK7nFMmcANU7ZP1w==",
+      "requires": {
+        "base64-js": "0.0.8",
+        "brfs": "^2.0.2",
+        "unicode-trie": "^1.0.0"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+        }
       }
     },
     "linked-list": {
@@ -9788,6 +10314,14 @@
         "yallist": "^2.1.2"
       }
     },
+    "magic-string": {
+      "version": "0.22.5",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
+      "requires": {
+        "vlq": "^0.2.2"
+      }
+    },
     "make-dir": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -9934,8 +10468,8 @@
       "dev": true
     },
     "mattermost-redux": {
-      "version": "github:rifflearning/mattermost-redux#b74dc2585c5332811e207785ea2208e16624adb3",
-      "from": "github:rifflearning/mattermost-redux#b74dc2585c5332811e207785ea2208e16624adb3",
+      "version": "github:rifflearning/mattermost-redux#929f602b6d2e08a98ceef9c904177d113179d153",
+      "from": "github:rifflearning/mattermost-redux#929f602b6d2e08a98ceef9c904177d113179d153",
       "requires": {
         "deep-equal": "1.0.1",
         "eslint-plugin-header": "1.2.0",
@@ -10046,6 +10580,14 @@
       "integrity": "sha512-dYOIAl9GFCJNctSIHWOj9OJtarCjsD16P8ObCl6oxrujAG+kOvlwJuOD9/O9iYZ9aTi1RGpGTG9q9etIvuUikQ==",
       "requires": {
         "is-what": "^3.3.1"
+      }
+    },
+    "merge-source-map": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+      "requires": {
+        "source-map": "^0.5.6"
       }
     },
     "merge-stream": {
@@ -10531,6 +11073,11 @@
       "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.6.tgz",
       "integrity": "sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=",
       "dev": true
+    },
+    "next-tick": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -11128,7 +11675,6 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
@@ -11624,6 +12170,160 @@
         "worker-loader": "^1.1.1"
       }
     },
+    "pdfkit": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/pdfkit/-/pdfkit-0.10.0.tgz",
+      "integrity": "sha512-mRJ6iuDzpIQ4ftKp5GvijLXNVRK86xjnyIPBraYSPrUPubNqWM5/oYmc7FZKUWz3wusRTj3PLR9HJ1X5ooqfsg==",
+      "requires": {
+        "crypto-js": "^3.1.9-1",
+        "fontkit": "^1.0.0",
+        "linebreak": "^0.3.0",
+        "png-js": ">=0.1.0"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+          "integrity": "sha1-EQHpVE9KdrG8OybUUsqW16NeeXg="
+        },
+        "brfs": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
+          "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
+          "requires": {
+            "quote-stream": "^1.0.1",
+            "resolve": "^1.1.5",
+            "static-module": "^2.2.0",
+            "through2": "^2.0.0"
+          }
+        },
+        "escodegen": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "linebreak": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-0.3.0.tgz",
+          "integrity": "sha1-BSZICmLAW9Z58+nZmDDgnGp9DtY=",
+          "requires": {
+            "base64-js": "0.0.8",
+            "brfs": "^1.3.0",
+            "unicode-trie": "^0.3.0"
+          }
+        },
+        "object-inspect": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
+          "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
+        },
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true
+        },
+        "static-module": {
+          "version": "2.2.5",
+          "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
+          "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
+          "requires": {
+            "concat-stream": "~1.6.0",
+            "convert-source-map": "^1.5.1",
+            "duplexer2": "~0.1.4",
+            "escodegen": "~1.9.0",
+            "falafel": "^2.1.0",
+            "has": "^1.0.1",
+            "magic-string": "^0.22.4",
+            "merge-source-map": "1.0.4",
+            "object-inspect": "~1.4.0",
+            "quote-stream": "~1.0.2",
+            "readable-stream": "~2.3.3",
+            "shallow-copy": "~0.0.1",
+            "static-eval": "^2.0.0",
+            "through2": "~2.0.3"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        },
+        "unicode-trie": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-0.3.1.tgz",
+          "integrity": "sha1-1nHd3YkQGgi6w3tqUWEBBgIFIIU=",
+          "requires": {
+            "pako": "^0.2.5",
+            "tiny-inflate": "^1.0.0"
+          }
+        }
+      }
+    },
+    "pdfmake": {
+      "version": "0.1.58",
+      "resolved": "https://registry.npmjs.org/pdfmake/-/pdfmake-0.1.58.tgz",
+      "integrity": "sha512-xLiLf47dBpONYQUP/dyy4TAVJtA79lEqd8vS02FBmKbbOcTzTRDongnJ095tf4q2b6UbT27VLgBRPA4vuiJK3w==",
+      "requires": {
+        "iconv-lite": "^0.5.0",
+        "linebreak": "^1.0.2",
+        "pdfkit": "^0.10.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.0.tgz",
+          "integrity": "sha512-NnEhI9hIEKHOzJ4f697DMz9IQEXr/MMJ5w64vN2/4Ai+wRnvV7SBrL0KLoRlwaKVghOc7LQ5YkPLuX146b6Ydw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3"
+          }
+        }
+      }
+    },
     "pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -11700,6 +12400,11 @@
       "integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
       "dev": true
     },
+    "png-js": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/png-js/-/png-js-0.1.1.tgz",
+      "integrity": "sha1-HMfCEjA6yr50Jj7DrHgAlYAkLZM="
+    },
     "pngjs": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
@@ -11733,6 +12438,14 @@
             "strip-eof": "^1.0.0"
           }
         }
+      }
+    },
+    "polylabel": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/polylabel/-/polylabel-1.0.2.tgz",
+      "integrity": "sha1-kMEWAvshemW3isIRCsX8sAtlJWA=",
+      "requires": {
+        "tinyqueue": "^1.1.0"
       }
     },
     "posix-character-classes": {
@@ -11812,8 +12525,7 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -11854,6 +12566,11 @@
           "dev": true
         }
       }
+    },
+    "printj": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/printj/-/printj-1.1.2.tgz",
+      "integrity": "sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ=="
     },
     "private": {
       "version": "0.1.8",
@@ -12077,6 +12794,16 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
+    },
+    "quote-stream": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+      "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
+      "requires": {
+        "buffer-equal": "0.0.1",
+        "minimist": "^1.1.3",
+        "through2": "^2.0.0"
+      }
     },
     "radix-router": {
       "version": "3.0.1",
@@ -13211,6 +13938,11 @@
         }
       }
     },
+    "regression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regression/-/regression-2.0.1.tgz",
+      "integrity": "sha1-jSnD6CJKEIUMNeM36FqLL6w7DIc="
+    },
     "relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -13445,6 +14177,14 @@
         "signal-exit": "^3.0.2"
       }
     },
+    "restructure": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/restructure/-/restructure-0.5.4.tgz",
+      "integrity": "sha1-9U591WNZD7NP1r9Vh2EJrsyyjeg=",
+      "requires": {
+        "browserify-optional": "^1.0.0"
+      }
+    },
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
@@ -13455,6 +14195,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/reverse-arguments/-/reverse-arguments-1.0.0.tgz",
       "integrity": "sha1-woCVo6khrHFdYYNN3s6QJ5kmZ80="
+    },
+    "rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0="
     },
     "rimraf": {
       "version": "2.7.1",
@@ -14047,6 +14792,19 @@
         "ajv-keywords": "^3.1.0"
       }
     },
+    "scope-analyzer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/scope-analyzer/-/scope-analyzer-2.0.5.tgz",
+      "integrity": "sha512-+U5H0417mnTEstCD5VwOYO7V4vYuSqwqjFap40ythe67bhMFL5C3UgPwyBv7KDJsqUBIKafOD57xMlh1rN7eaw==",
+      "requires": {
+        "array-from": "^2.1.1",
+        "es6-map": "^0.1.5",
+        "es6-set": "^0.1.5",
+        "es6-symbol": "^3.1.1",
+        "estree-is-function": "^1.0.0",
+        "get-assigned-identifiers": "^1.1.0"
+      }
+    },
     "scss-tokenizer": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
@@ -14299,6 +15057,11 @@
           "dev": true
         }
       }
+    },
+    "shallow-copy": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
     },
     "shallow-equals": {
       "version": "1.0.0",
@@ -14903,6 +15666,14 @@
         }
       }
     },
+    "ssf": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.10.2.tgz",
+      "integrity": "sha512-rDhAPm9WyIsY8eZEKyE8Qsotb3j/wBdvMWBUsOhJdfhKGLfQidRjiBUV0y/MkyCLiXQ38FG6LWW/VYUtqlIDZQ==",
+      "requires": {
+        "frac": "~1.1.2"
+      }
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -14941,6 +15712,19 @@
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==",
       "dev": true
     },
+    "stackblur-canvas": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.2.0.tgz",
+      "integrity": "sha512-5Gf8dtlf8k6NbLzuly2NkGrkS/Ahh+I5VUjO7TnFizdJtgpfpLLEdQlLe9umbcnZlitU84kfYjXE67xlSXfhfQ=="
+    },
+    "static-eval": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
+      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
+      "requires": {
+        "escodegen": "^1.8.1"
+      }
+    },
     "static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -14958,6 +15742,89 @@
           "dev": true,
           "requires": {
             "is-descriptor": "^0.1.0"
+          }
+        }
+      }
+    },
+    "static-module": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-3.0.3.tgz",
+      "integrity": "sha512-RDaMYaI5o/ym0GkCqL/PlD1Pn216omp8fY81okxZ6f6JQxWW5tptOw9reXoZX85yt/scYvbWIt6uoszeyf+/MQ==",
+      "requires": {
+        "acorn-node": "^1.3.0",
+        "concat-stream": "~1.6.0",
+        "convert-source-map": "^1.5.1",
+        "duplexer2": "~0.1.4",
+        "escodegen": "~1.9.0",
+        "has": "^1.0.1",
+        "magic-string": "^0.22.4",
+        "merge-source-map": "1.0.4",
+        "object-inspect": "~1.4.0",
+        "readable-stream": "~2.3.3",
+        "scope-analyzer": "^2.0.1",
+        "shallow-copy": "~0.0.1",
+        "static-eval": "^2.0.2",
+        "through2": "~2.0.3"
+      },
+      "dependencies": {
+        "escodegen": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+          "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+          "requires": {
+            "esprima": "^3.1.3",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "optionator": "^0.8.1",
+            "source-map": "~0.6.1"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "object-inspect": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
+          "integrity": "sha512-wqdhLpfCUbEsoEwl3FXwGyv8ief1k/1aUdIPCqVnupM6e8l63BEJdiF/0swtn04/8p05tG/T0FrpTlfwvljOdw=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "optional": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -15638,14 +16505,12 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
       "requires": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -15654,14 +16519,12 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-          "dev": true
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "readable-stream": {
           "version": "2.3.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -15675,14 +16538,12 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -15710,6 +16571,11 @@
         "setimmediate": "^1.0.4"
       }
     },
+    "tiny-inflate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.2.tgz",
+      "integrity": "sha1-k9nez/yIBb1X6uQxDwt0Xptvs6c="
+    },
     "tiny-invariant": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.6.tgz",
@@ -15724,6 +16590,11 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
+    },
+    "tinyqueue": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-1.2.3.tgz",
+      "integrity": "sha512-Qz9RgWuO9l8lT+Y9xvbzhPT2efIUIFd69N7eF7tJ9lnQl0iLj1M7peK7IoUGZL9DJHw9XftqLreccfxcQgYLxA=="
     },
     "tmp": {
       "version": "0.0.33",
@@ -15896,8 +16767,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "tty-browserify": {
       "version": "0.0.0",
@@ -15925,11 +16795,15 @@
       "resolved": "https://registry.npmjs.org/twemoji/-/twemoji-11.0.1.tgz",
       "integrity": "sha512-Z0bRyZ1yO7cqa69oRhLZWmaLM0e9eeTugUXbnNQY3XPgRHJcSF8PKfp/dx3vHWtz9Y6o8fi3Ryjfpq4vBCeXjA=="
     },
+    "type": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.3.tgz",
+      "integrity": "sha512-51IMtNfVcee8+9GJvj0spSuFcZHe9vSib6Xtgsny1Km9ugyz2mbS08I3rsUIRYgJohFRFU1160sgRodYz378Hg=="
+    },
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -15955,8 +16829,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "ua-parser-js": {
       "version": "0.7.20",
@@ -16091,6 +16964,31 @@
         "compose-function": "^2.0.0",
         "reverse-arguments": "1.0.0",
         "underscore.string": "3.0.3"
+      }
+    },
+    "unicode-properties": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/unicode-properties/-/unicode-properties-1.2.2.tgz",
+      "integrity": "sha512-+WhsOj19c93rPymvnPnFisbgFzrI4LjTV8ejMcCCfwS0XhdllZB4NsMFiYb4xUmpn3+aj3PM40h+wlzoG7PCnQ==",
+      "requires": {
+        "base64-js": "^1.3.0",
+        "unicode-trie": "^1.0.0"
+      }
+    },
+    "unicode-trie": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-1.0.0.tgz",
+      "integrity": "sha512-v5raLKsobbFbWLMoX9+bChts/VhPPj3XpkNr/HbqkirXR1DPk8eo9IYKyvk0MQZFkaoRsFj2Rmaqgi2rfAZYtA==",
+      "requires": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+        }
       }
     },
     "union-value": {
@@ -16371,6 +17269,11 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "vlq": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow=="
     },
     "vm-browserify": {
       "version": "1.1.0",
@@ -17629,8 +18532,7 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
     },
     "worker-farm": {
       "version": "1.7.0",
@@ -17734,6 +18636,27 @@
         "xtend": "^4.0.0"
       }
     },
+    "xlsx": {
+      "version": "0.12.13",
+      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.12.13.tgz",
+      "integrity": "sha512-9/2H4PLphmG8sDvI3mfWb6JIFqbvK8IRGhgS55Pw5F+fmKPuzdv4OW9RFjrH5PiTKeqB/883Z8o+jW3JrDahmw==",
+      "requires": {
+        "adler-32": "~1.2.0",
+        "cfb": "~1.0.7",
+        "codepage": "~1.13.0",
+        "commander": "~2.15.1",
+        "crc-32": "~1.2.0",
+        "exit-on-epipe": "~1.0.1",
+        "ssf": "~0.10.2"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.15.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+          "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag=="
+        }
+      }
+    },
     "xml": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
@@ -17781,8 +18704,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "dev": true
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "./client/web_client.jsx": "./client/browser_web_client.jsx"
   },
   "dependencies": {
+    "@amcharts/amcharts4": "^4.5.14",
     "@feathersjs/authentication-client": "^1.0.11",
     "@feathersjs/feathers": "^3.2.3",
     "@feathersjs/socketio-client": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "localforage-observable": "1.4.0",
     "marked": "github:mattermost/marked#ed33baecd7d7fa97d479ba22dde9d226b083d67d",
     "material-icons-react": "^1.0.4",
-    "mattermost-redux": "github:rifflearning/mattermost-redux#b74dc2585c5332811e207785ea2208e16624adb3",
+    "mattermost-redux": "github:rifflearning/mattermost-redux#929f602b6d2e08a98ceef9c904177d113179d153",
     "moment-timezone": "0.5.21",
     "pdfjs-dist": "2.0.489",
     "perfect-scrollbar": "0.8.1",

--- a/reducers/views/webrtc.js
+++ b/reducers/views/webrtc.js
@@ -20,7 +20,7 @@ const initialState = {
         Colors.sage,
         Colors.apricot,
         Colors.eggplant,
-        Colors.darkfern,
+        Colors.darkFern,
         Colors.aquamarine,
     ],
     getMediaStatus: 'error',

--- a/utils/riff/collection_utils.js
+++ b/utils/riff/collection_utils.js
@@ -1,0 +1,112 @@
+/* ******************************************************************************
+ * collection_utils.js                                                          *
+ * *************************************************************************/ /**
+ *
+ * @fileoverview utils to help manipulating collections (arrays, dictionaries ie objects)
+ *
+ * These utility functions were create to help removing the use of the
+ * underscore package for functionality which is basically now supplied as
+ * part of the ecmascript language, particularly given these small functions.
+ *
+ * Created on       April 15, 2019
+ * @author          Michael Jay Lippert
+ *
+ * @copyright (c) 2018-present Riff Learning Inc.,
+ *            MIT License (see https://opensource.org/licenses/MIT)
+ *
+ * ******************************************************************************/
+
+// Riff Learning lint overrides
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" }, "ObjectExpression": "first" }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+*/
+
+/**
+ * Returns an object whose properties are the values of the specified
+ * property of the members of the given array. The value of those
+ * properties is an array containing the members of the original
+ * array with the property with that value.
+ *
+ * Replaces one use of the underscore package's groupBy function.
+ */
+function groupByPropertyValue(a, p) {
+    return a.reduce((grouped, cur) => {
+        if (!(cur[p] in grouped)) {
+            grouped[cur[p]] = [];
+        }
+        grouped[cur[p]].push(cur);
+        return grouped;
+    }, {});
+}
+
+/**
+ * Returns an object whose properties are the values of the specified
+ * property of the members of the given array. The value of those
+ * properties is the count of the number of elements in the original
+ * array with that property value.
+ *
+ * Replaces one use of the underscore package's countBy function.
+ */
+function countByPropertyValue(a, p) {
+    return a.reduce((grouped, cur) => {
+        if (!(cur[p] in grouped)) {
+            grouped[cur[p]] = 0;
+        }
+        ++grouped[cur[p]];
+        return grouped;
+    }, {});
+}
+
+/**
+ * Returns a new object with the same properties as the given
+ * object, but whose values are those returned by the given
+ * function. The given function takes 2 args, the property
+ * value and the property key.
+ *
+ * Replaces the underscore mapObject function.
+ */
+function mapObject(o, f) {
+    const newO = {...o};
+    for (const [k, v] of Object.entries(newO)) {
+        newO[k] = f(v, k);
+    }
+    return newO;
+}
+
+/**
+ * Get a comparison functor for the property of an object whose
+ * values can be compared using the standard comparison operators.
+ *
+ * @returns {function(a, b)}
+ *      A function that takes 2 object, a and b, and returns
+ *      -1 if a[prop] < b[prop], 1 if a[prop] > b[prop], 0 if a[prop] = b[prop]
+ */
+function cmpObjectProp(prop) {
+    return (a, b) => {
+        return a[prop] < b[prop] ? -1 : a[prop] > b[prop] ? 1 : 0; // eslint-disable-line no-nested-ternary
+    };
+}
+
+/**
+ * Return a function that reverses the sense of the given comparison
+ * functor. So when used with the Array.sort it will turn an ascending
+ * sort into a descending sort (and vice-versa).
+ */
+function reverseCmp(cmp) {
+    return (a, b) => cmp(b, a);
+}
+
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    cmpObjectProp,
+    countByPropertyValue,
+    groupByPropertyValue,
+    mapObject,
+    reverseCmp,
+};

--- a/utils/riff/colors.js
+++ b/utils/riff/colors.js
@@ -1,0 +1,169 @@
+/* ******************************************************************************
+ * colors.js                                                                    *
+ * *************************************************************************/ /**
+ *
+ * @fileoverview Colors used by Riff
+ *
+ * By naming the color values it is easier to track where they are used and
+ * to be more consistent in the use of colors.
+ *
+ * Created on       April 15, 2019
+ * @author          Michael Jay Lippert
+ *
+ * @copyright (c) 2018-present Riff Learning Inc.,
+ *            MIT License (see https://opensource.org/licenses/MIT)
+ *
+ * ******************************************************************************/
+
+// Riff Learning lint overrides
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" }, "ObjectExpression": "first" }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+    "no-multi-spaces": [ "error", { "ignoreEOLComments": true, "exceptions": { "Property": true } } ],
+    "key-spacing": [ "error", { "mode": "minimum" } ],
+*/
+
+/**
+ * Give some name to colors we may want to use
+ * I lifted names from https://graf1x.com/list-of-colors-with-color-names/ that are
+ * similar, but the colors below ARE NOT the official colors for those name!
+ * It's just important to have a more easily recognizable name than the color value
+ * in order to determine where the same color is used in the code.
+ * Keep this enum sorted by color value to make it easier to find a color.
+ */
+const Colors = {
+    black:            '#000000',
+    turkoise:         '#128ead',
+    aquamarine:       '#1b998b',
+    eggplant:         '#321325',
+    darkFern:         '#3c493f',
+    lightAnchor:      '#576066',
+    lightAnchor2:     '#607071',
+    sage:             '#7caf5f',
+    mauve:            '#85638c',
+    lightRoyal:       '#8a6a94',
+    africanLollipop:  '#923a92',
+    brightPlum:       '#ab45ab',
+    lightLava:        '#bdc3c7',
+    apricot:          '#f2a466',
+    brightRed:        '#f44336',
+    reddishPeach:     '#f56b6b',
+    purpleWhite:      '#f6f0fb',
+    redPunch:         '#ff6384',
+    white:            '#ffffff',
+};
+
+/**
+ * List of colors to use for peers in charts and other places it is
+ * useful to associate a color to help distinguish a list of "things".
+ * Use the 1st color (peerColors[0]) as the self color when that matters.
+ *
+ * Note: Where possible, using css would be preferable to using these colors
+ * so this list also exist and needs to be kept in sync w/ what's in
+ * sass/components/_bulma.scss
+ */
+const PeerColors = [
+    Colors.brightPlum,
+    Colors.reddishPeach,
+    Colors.turkoise,
+    Colors.sage,
+    Colors.apricot,
+    Colors.eggplant,
+    Colors.darkFern,
+    Colors.aquamarine,
+];
+
+/**
+ * Append a hex opacity value to a hex color string
+ * Currently only supports 6 digit color string of the form
+ * '#rrggbb' e.g. '#4c338a'
+ *
+ * @example rgba(Colors.brightPlum, 0.5) returns '#ab45ab80'
+ *
+ * @param {string} hexColor
+ * @param {number} opacity - fractional opacity, from 0 (totally clear) to 1 (totally opaque)
+ *
+ * @returns {string} a hex color string including the opacity (#rrggbbaa)
+ *    e.g. '#ab45ab80'
+ */
+function rgbaColor(hexColor, opacity) {
+    // convert opacity to hex value
+    const hexOpacity = Math.round(0xff * opacity).toString(16);
+    return `${hexColor}${hexOpacity.length === 1 ? '0' : ''}${hexOpacity}`;
+}
+
+/**
+ * Get the color to use for the current user/self.
+ * Returns the first entry in PeerColors.
+ *
+ * @returns {ColorString} a color string for the current user/self.
+ */
+function getColorForSelf() {
+    return PeerColors[0];
+}
+
+/**
+ * Get the color to use for the nth other.
+ * Returns a color from PeerColors (that is not the 1st entry which is reserved
+ * for the 'self' color)
+ * Colors will be "reused" for values of n > the number of PeerColors.
+ *
+ * @param {number} n
+ *      The number (0 based index) of an other to get a color string for.
+ *
+ * @returns {ColorString} a color string for the nth other.
+ */
+function getColorForOther(n) {
+    const i = (n % (PeerColors.length - 1)) + 1;
+    return PeerColors[i];
+}
+
+/* ******************************************************************************
+ * getCountOtherColors                                                     */ /**
+ *
+ * Get an array of colors for count others. The colors will be taken from
+ * PeerColors, excluding the 1st entry which is reserved for the 'self' color.
+ * Colors will be repeated as necessary in order to return count colors.
+ *
+ * @param {number} cnt
+ *      The number of colors to be returned
+ *
+ * @returns {Array<ColorString>} an array of count color strings.
+ */
+function getCountOtherColors(cnt) {
+    // 0 or anything else falsy should just return an empty array
+    if (!cnt) {
+        return [];
+    }
+
+    const numDistinctOtherColors = PeerColors.length - 1;
+    const colorListDups = Math.trunc(numDistinctOtherColors / cnt);
+    const extraColors = numDistinctOtherColors % cnt;
+
+    const cntOtherColors = [];
+    if (colorListDups > 0) {
+        const otherColors = PeerColors.slice(1);
+        for (let i = colorListDups; i > 0; --i) {
+            cntOtherColors.push(...otherColors);
+        }
+    }
+
+    cntOtherColors.push(...PeerColors.slice(1, extraColors + 1));
+
+    return cntOtherColors;
+}
+
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    Colors,
+    PeerColors,
+    getColorForSelf,
+    getColorForOther,
+    getCountOtherColors,
+    rgbaColor,
+};

--- a/utils/riff/colors.js
+++ b/utils/riff/colors.js
@@ -77,6 +77,38 @@ const PeerColors = [
 ];
 
 /**
+ * List of color objects to use for nodes in the interaction network graph
+ * Each color object has a background and font color property in order to
+ * comply with accessbility requirements
+ *
+ * TODO: Give these raw colors names in the Colors enum above.
+ */
+const networkGraphNodeColors = {
+    you: {
+        backgroundColor: '#8e7cc3', // purple
+        fontColor: Colors.white,
+    },
+    course: {
+        backgroundColor: '#6aa84f', // green
+        fontColor: Colors.black,
+    },
+    learningGroupColors: [
+        {
+            backgroundColor: '#2b78e4', // blue
+            fontColor: Colors.black,
+        },
+        {
+            backgroundColor: '#f6b26b', // orange
+            fontColor: Colors.black,
+        },
+        {
+            backgroundColor: '#db4c40', // red
+            fontColor: Colors.black,
+        },
+    ],
+};
+
+/**
  * Append a hex opacity value to a hex color string
  * Currently only supports 6 digit color string of the form
  * '#rrggbb' e.g. '#4c338a'
@@ -156,6 +188,22 @@ function getCountOtherColors(cnt) {
     return cntOtherColors;
 }
 
+/**
+ * Get the color to use for the nth course connections learning group type.
+ * Returns a value from networkGraphNodeColors.learningGroupColors
+ * Colors will be "reused" for values of n > the number of learningGroupColors.
+ *
+ * @param {number} n
+ *      The number (0 based index) of a learning group type to get a color string for.
+ *
+ * @returns {{ backgroundColor: ColorString, fontColor: ColorString }} an object
+ *      containing the background and font colors for the nth learning group.
+ */
+function getColorForLearningGroup(n) {
+    const i = (n % (networkGraphNodeColors.learningGroupColors.length - 1)) + 1;
+    return networkGraphNodeColors.learningGroupColors[i];
+}
+
 /* **************************************************************************** *
  * Module exports                                                               *
  * **************************************************************************** */
@@ -165,5 +213,7 @@ export {
     getColorForSelf,
     getColorForOther,
     getCountOtherColors,
+    getColorForLearningGroup,
+    networkGraphNodeColors,
     rgbaColor,
 };

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -1,65 +1,45 @@
 // Copyright (c) 2018-present Riff Learning, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint header/header: "off", dot-location: ["error", "property"] */
+// Riff Learning lint overrides
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" }, "ObjectExpression": "first" }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+*/
 
 import feathers from '@feathersjs/feathers';
 import socketio from '@feathersjs/socketio-client';
 import auth from '@feathersjs/authentication-client';
 import io from 'socket.io-client';
 
-// access to api
-
-/* eslint-disable no-console, no-empty-function */
-// Noop function to use for disabled log levels
-const noopFn = () => {};
-
-const infoLog = console.log.bind(window.console);
-const warnLog = console.warn.bind(window.console);
-const errorLog = console.error.bind(window.console);
-/* eslint-enable no-console, no-empty-function */
-
-/**
- * logger is a poor man's cheap logger for client code.
- *
- * It mostly just redirects to using the window console
- * log, EXCEPT it allows debug logging to be enabled or
- * disabled.
- *
- * By using this logger instead of console.log directly
- * we can more easily replace all logging with a fancier
- * logger package w/ more functionality at some later time
- * if desired.
- */
-export const logger = {
-    debug: infoLog,
-    info: infoLog,
-    warn: warnLog,
-    error: errorLog,
-
-    setLogLevel(level) {
-        this.debug = noopFn;
-        this.info = noopFn;
-        this.warn = noopFn;
-        this.error = noopFn;
-
-        /* eslint-disable no-fallthrough */
-        switch (level) {
-        case 'debug':
-            this.debug = infoLog;
-        case 'info':
-            this.info = infoLog;
-        case 'warn':
-            this.warn = warnLog;
-        case 'error':
-            this.error = errorLog;
-        }
-        /* eslint-enable no-fallthrough */
-    },
-};
+import {logger} from './logger';
+import {
+    cmpObjectProp,
+    countByPropertyValue,
+    groupByPropertyValue,
+    mapObject,
+    reverseCmp,
+} from './collection_utils';
+import {
+    Colors,
+    PeerColors,
+    getColorForOther,
+    getColorForSelf,
+    getCountOtherColors,
+    rgbaColor,
+} from './colors';
+import {
+    WebRtcNick,
+    calculateBitrate,
+    isScreenShareSourceAvailable,
+    readablePeers,
+} from './webrtc_utils';
 
 // Default dataserver and signalmaster url and path values which work w/ the reverse proxy
-export const config = {
+const config = {
     logLevel: 'debug',
     dataserverUrl: '/',
     dataserverPath: '/api/videodata',
@@ -90,7 +70,7 @@ config.signalmasterPath = configSignalmasterPath !== undefined ? configSignalmas
 
 logger.debug('data server socket:', {url: config.dataserverUrl, path: config.dataserverPath + '/socket.io'});
 
-export const socket = io(config.dataserverUrl, {
+const socket = io(config.dataserverUrl, {
     timeout: 20000,
     path: config.dataserverPath + '/socket.io',
     transports: [
@@ -102,118 +82,20 @@ export const socket = io(config.dataserverUrl, {
     ],
 });
 
-export var app = feathers()
+const app = feathers()
     .configure(socketio(socket))
     .configure(auth({jwt: {}, local: {}}));
-
-/**
- * Returns an object whose properties are the values of the specified
- * property of the members of the given array. The value of those
- * properties is an array containing the members of the original
- * array with the property with that value.
- *
- * Replaces one use of the underscore package's groupBy function.
- */
-export function groupByPropertyValue(a, p) {
-    return a.reduce((grouped, cur) => {
-        if (!(cur[p] in grouped)) {
-            grouped[cur[p]] = [];
-        }
-        grouped[cur[p]].push(cur);
-        return grouped;
-    }, {});
-}
-
-/**
- * Returns a new object with the same properties as the given
- * object, but whose values are those returned by the given
- * function. The given function takes 2 args, the property
- * value and the property key.
- *
- * Replaces the underscore mapObject function.
- */
-export function mapObject(o, f) {
-    const newO = {...o};
-    for (const [k, v] of Object.entries(newO)) {
-        newO[k] = f(v, k);
-    }
-    return newO;
-}
-
-/**
- * Get a comparison functor for the property of an object whose
- * values can be compared using the standard comparison operators.
- *
- * @returns {function(a, b)}
- *      A function that takes 2 object, a and b, and returns
- *      -1 if a[prop] < b[prop], 1 if a[prop] > b[prop], 0 if a[prop] = b[prop]
- */
-export function cmpObjectProp(prop) {
-    return (a, b) => {
-        return a[prop] < b[prop] ? -1 : a[prop] > b[prop] ? 1 : 0; // eslint-disable-line no-nested-ternary
-    };
-}
-
-/**
- * Return a function that reverses the sense of the given comparison
- * functor. So when used with the Array.sort it will turn an ascending
- * sort into a descending sort (and vice-versa).
- */
-export function reverseCmp(cmp) {
-    return (a, b) => cmp(b, a);
-}
 
 /**
  * Returns the time difference in seconds between the given
  * start and end times.
  */
-export function getDurationInSeconds(startTime, endTime) {
+function getDurationInSeconds(startTime, endTime) {
     const start = new Date(startTime);
     const end = new Date(endTime);
     const durationSecs = (end.getTime() - start.getTime()) / 1000;
     return durationSecs;
 }
-
-/**
- * Give some name to colors we may want to use
- * I lifted names from https://graf1x.com/list-of-colors-with-color-names/ that are
- * similar, but the colors below ARE NOT the official colors for those name!
- * It's just important to have a more easily recognizable name than the color value
- * in order to determine where the same color is used in the code.
- */
-export const Colors = {
-    brightPlum: '#ab45ab',
-    reddishPeach: '#f56b6b',
-    turkoise: '#128ead',
-    sage: '#7caf5f',
-    apricot: '#f2a466',
-    eggplant: '#321325',
-    darkfern: '#3c493f',
-    aquamarine: '#1b998b',
-    lightlava: '#bdc3c7',
-    lightroyal: '#8a6a94',
-    brightred: '#f44336',
-};
-
-/**
- * List of colors to use for peers in charts and other places it is
- * useful to associate a color to help distinguish a list of "things".
- * Use the 1st color (peerColors[0]) as the self color when that matters.
- *
- * Note: Where possible, using css would be preferable to using these colors
- * so this list also exist and needs to be kept in sync w/ what's in
- * sass/components/_bulma.scss
- */
-export const PeerColors = [
-    Colors.brightPlum,
-    Colors.reddishPeach,
-    Colors.turkoise,
-    Colors.sage,
-    Colors.apricot,
-    Colors.eggplant,
-    Colors.darkfern,
-    Colors.aquamarine,
-];
 
 /**
  * Limit the given string to the specifed number of characters.
@@ -230,7 +112,7 @@ export const PeerColors = [
  *
  * @returns a string with a maximum of maxLen characters
  */
-export function textTruncate(s, maxLen = 100, missingCharSuffix = '\u2026') {
+function textTruncate(s, maxLen = 100, missingCharSuffix = '\u2026') {
     if (s.length <= maxLen) {
         return s;
     }
@@ -248,7 +130,7 @@ export function textTruncate(s, maxLen = 100, missingCharSuffix = '\u2026') {
  *    2. 'polite'(default) - will be read when current speech completes
  *    *Note: these are standards, but exact functionality can vary between screen readers
  */
-export function addA11yBrowserAlert(text, priority = 'polite') {
+function addA11yBrowserAlert(text, priority = 'polite') {
     const newAlert = document.createElement('div');
     const id = 'speak-' + Date.now();
 
@@ -269,60 +151,30 @@ export function addA11yBrowserAlert(text, priority = 'polite') {
     }, 1000);
 }
 
-/**
- * Convert a peer array into a readable string listing those peers
- * using their nicknames.
- * Useful for a11y aria labels.
- *
- * examples:
- * 0 peers: 'Nobody else is here.'
- * 1 peer : 'Gerald is in the room.'
- * 2 peers: 'Aretha and Patty are in the room.'
- * 3 peers: 'Gerald, Tony and Markus are in the room.'
- * 4 peers: 'Liz, Gerald, Rebecca and Markus are in the room.'
- */
-export function readablePeers(peers) {
-    // No peers is easy
-    if (peers.length === 0) {
-        return 'Nobody else is here.';
-    }
-
-    const readableSuffix = 'in the room.';
-    const peerNames = peers.map((p) => p.nick.split('|')[1]);
-
-    // 1 peer is easy
-    if (peerNames.length === 1) {
-        return `${peerNames[0]} is ${readableSuffix}`;
-    }
-
-    // comma separate all names except the last one which is separated by 'and'
-    const readablePeerList = [peerNames.slice(0, -1).join(', '), peerNames.slice(-1)].join(' and ');
-
-    // multiple peers
-    return `${readablePeerList} are ${readableSuffix}`;
-}
-
-/** The minimum acceptable bitrate for a single stream */
-const MIN_BITRATE = 300; // kbps
-
-/** The maximum allowable total bandwidth consumed by all streams
- *  given that our requirements state a minimum bandwidth
- *  of 3 megabits per second, we come in just a bit below that
- */
-const MAX_BANDWIDTH = 2700; // kbps
-
-/**
- * Returns the appropriate bitrate (kbps) for the video streams
- * based on the number of other peers in the meeting
- * (e.g. if 2 total people are in a meeting, peerCount is 1)
- */
-export function calculateBitrate(peerCount) {
-    // if we have four or more peers,
-    // we just want to use the lowest possible bitrate
-    // to avoid any cpu limitations
-    if (peerCount >= 4) {
-        return MIN_BITRATE;
-    }
-
-    return MAX_BANDWIDTH / peerCount;
-}
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    config,
+    socket,
+    app,
+    getDurationInSeconds,
+    textTruncate,
+    addA11yBrowserAlert,
+    logger,
+    cmpObjectProp,
+    countByPropertyValue,
+    groupByPropertyValue,
+    mapObject,
+    reverseCmp,
+    Colors,
+    PeerColors,
+    getColorForOther,
+    getColorForSelf,
+    getCountOtherColors,
+    rgbaColor,
+    WebRtcNick,
+    calculateBitrate,
+    isScreenShareSourceAvailable,
+    readablePeers,
+};

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -26,9 +26,11 @@ import {
 import {
     Colors,
     PeerColors,
+    getColorForLearningGroup,
     getColorForOther,
     getColorForSelf,
     getCountOtherColors,
+    networkGraphNodeColors,
     rgbaColor,
 } from './colors';
 import {
@@ -169,9 +171,11 @@ export {
     reverseCmp,
     Colors,
     PeerColors,
+    getColorForLearningGroup,
     getColorForOther,
     getColorForSelf,
     getCountOtherColors,
+    networkGraphNodeColors,
     rgbaColor,
     WebRtcNick,
     calculateBitrate,

--- a/utils/riff/logger.js
+++ b/utils/riff/logger.js
@@ -1,0 +1,94 @@
+/* ******************************************************************************
+ * logger.js                                                                    *
+ * *************************************************************************/ /**
+ *
+ * @fileoverview A very rudimentary logger
+ *
+ * logger is a poor man's cheap logger for client code.
+ *
+ * It provides debug, info, warn and error logging to the console, with the
+ * ability to set the log level such that only log messages of a certain
+ * level will be logged.
+ *
+ * Created on       April 15, 2019
+ * @author          Michael Jay Lippert
+ *
+ * @copyright (c) 2019-present Riff Learning Inc.,
+ *            MIT License (see https://opensource.org/licenses/MIT)
+ *
+ * ******************************************************************************/
+
+// Riff Learning lint overrides
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" }, "ObjectExpression": "first" }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+*/
+
+/* eslint-disable no-console, no-empty-function */
+// Noop function to use for disabled log levels
+const noopFn = () => {};
+
+const infoLog = console.log.bind(window.console);
+const warnLog = console.warn.bind(window.console);
+const errorLog = console.error.bind(window.console);
+/* eslint-enable no-console, no-empty-function */
+
+/** The current log level */
+let curLogLevel = 'debug';
+
+/**
+ * logger is a poor man's cheap logger for client code.
+ *
+ * It mostly just redirects to using the window console
+ * log, EXCEPT it allows setting a log level which will
+ * disable all logging of a lower level (debug is lowest,
+ * error is highest).
+ *
+ * By using this logger instead of console.log directly
+ * we can more easily replace all logging with a fancier
+ * logger package w/ more functionality at some later time
+ * if desired.
+ */
+const logger = {
+    debug: infoLog,
+    info: infoLog,
+    warn: warnLog,
+    error: errorLog,
+
+    setLogLevel(level) {
+        curLogLevel = level;
+        this.debug = noopFn;
+        this.info = noopFn;
+        this.warn = noopFn;
+        this.error = noopFn;
+
+        /* eslint-disable no-fallthrough */
+        switch (level) {
+        case 'debug':
+            this.debug = infoLog;
+        case 'info':
+            this.info = infoLog;
+        case 'warn':
+            this.warn = warnLog;
+        case 'error':
+            this.error = errorLog;
+        }
+        /* eslint-enable no-fallthrough */
+    },
+
+    getLogLevel() {
+        return curLogLevel;
+    },
+};
+
+logger.setLogLevel(curLogLevel);
+
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    logger,
+};

--- a/utils/riff/user_analytic_utils.js
+++ b/utils/riff/user_analytic_utils.js
@@ -1,0 +1,202 @@
+// Copyright (c) 2019-present Riff Learning, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Riff Learning lint overrides
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" }, "ObjectExpression": "first" }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+    "generator-star-spacing": ["error", { "before": false, "after": true, "method": "neither" } ],
+*/
+
+/** Enumeration of all possible user interaction types */
+const InteractionTypes = [
+    'Reaction',
+    'Mention',
+    'DirectMessage',
+    'Reply',
+];
+
+/* ******************************************************************************
+ * InteractionContext                                                      */ /**
+ *
+ * An interaction context in which interactions took place (ex. the course
+ * context, or a learning group context)
+ *
+ ********************************************************************************/
+class InteractionContext {
+    /**
+     * InteractionContext class constructor.
+     *
+     * There is no default ctor which instantiates an InteractionContext
+     * w/ default values when none are given.
+     *
+     * @param {!InteractionContext.Config} config
+     *      The settings to configure this InteractionContext
+     */
+    constructor(config) {
+        // instance properties
+        this.name = config.name;
+        this.type = config.type;
+        this.chartNodeData = config.chartNodeData;
+
+        /**
+         * map by username of interactions that user had with the current user
+         * in this interaction context.
+         * @type {Object<UserInContext>}
+         */
+        this.users = {};
+    }
+
+    /**
+     * Count all the interaction records by incrementing the appropriate
+     * UserInContext record (creating one if it doesn't exist) in the
+     * users map.
+     *
+     * @param {Array} interactions
+     *      Array of interaction records in the specified context
+     *      to be added to the current counts.
+     */
+    addUserInteractions(interactions) {
+        // Add each interaction to the appropriate UserInContext instance
+        for (const interaction of interactions) {
+            const username = interaction.username;
+            let userInContext = this.users[username];
+            if (!userInContext) {
+                // first occurance of this user in this context, create a new UserInContext for them
+                userInContext = new UserInContext({username, contextType: this.type});
+                this.users[username] = userInContext;
+            }
+
+            userInContext.incInteractionCount(interaction.interaction_type);
+        }
+    }
+
+    /**
+     * Ensure that there is a UserInContext record in the users map
+     * for the given usernames. Any new records created will have
+     * interaction type counts of 0.
+     *
+     * @param {Array<string>} usernames
+     *      Array of usernames that must exist in the users map
+     */
+    addUsers(usernames) {
+        // undefined or null is the same as no usernames to add so just return
+        if (!usernames) {
+            return;
+        }
+
+        for (const username of usernames) {
+            if (!(username in this.users)) {
+                // username wasn't found, create a new UserInContext for them
+                this.users[username] = new UserInContext({username, contextType: this.type});
+            }
+        }
+    }
+
+    /**
+     * Make InteractionContext iterable over the defined users
+     *
+     * DevNote: This is a generator function with the property
+     * name that makes instances of the class iterable.
+     * see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators}
+     */
+    *[Symbol.iterator]() {
+        for (const userInContext of Object.values(this.users)) {
+            yield userInContext;
+        }
+    }
+}
+
+/* ******************************************************************************
+ * InteractionContext.Config                                               */ /**
+ *
+ * The InteractionContext.Config defines the object passed to the constructor that
+ * contains options/values used to initialize an instance of a InteractionContext.
+ *
+ * @typedef {!Object} InteractionContext.Config
+ *
+ * @property {string} name
+ *      a name for this context (is the channel slug name or 'course')
+ *
+ * @property {string} type
+ *      the type of context (learning group type's prefix or 'course')
+ *
+ * @property {Object} chartNodeData
+ *      containing the node data for the node on the graph for this context
+ *
+ * @property {Object<UserInContext>} users
+ *      containing the users to be displayed in this context (with usernames as keys)
+ */
+
+/* ******************************************************************************
+ * UserInContext                                                           */ /**
+ *
+ * Interaction data for a user in a context (ex. in the course context)
+ *
+ ********************************************************************************/
+class UserInContext {
+    /**
+     * UserInContext class constructor.
+     *
+     * @param {!UserInContext.Config} config
+     *      The settings to configure this UserInContext
+     */
+    constructor(config) {
+        // instance properties
+        this.username = config.username;
+        this.contextType = config.contextType;
+
+        // initialize the interaction map
+        /* eslint-disable-next-line brace-style, max-statements-per-line */
+        this.interactionMap = InteractionTypes.reduce((map, type) => { map[type] = 0; return map; }, {});
+    }
+
+    /**
+     * Get the interaction count of the specified type of interaction.
+     */
+    getInteractionCount(type) {
+        return this.interactionMap[type];
+    }
+
+    /**
+     * Get the aggregate count of all interactions.
+     */
+    getInteractionAggregate() {
+        return Object.values(this.interactionMap).reduce((a, b) => a + b);
+    }
+
+    /**
+     * Increment the interaction count of the specified type of interaction.
+     */
+    incInteractionCount(type) {
+        this.interactionMap[type]++;
+    }
+}
+
+/* ******************************************************************************
+ * UserInContext.Config                                                    */ /**
+ *
+ * The UserInContext.Config defines the object passed to the constructor that
+ * contains options/values used to initialize an instance of a UserInContext.
+ *
+ * @typedef {!Object} UserInContext.Config
+ *
+ * @property {string} username
+ *      username of user
+ *
+ * @property {string} contextType
+ *      context of the interactions with this user ('course' or a learning group
+ *      type prefix)
+ */
+
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    InteractionTypes,
+    InteractionContext,
+    UserInContext,
+};

--- a/utils/riff/webrtc_utils.js
+++ b/utils/riff/webrtc_utils.js
@@ -1,0 +1,230 @@
+/* ******************************************************************************
+ * webrtc_utils.js                                                              *
+ * *************************************************************************/ /**
+ *
+ * @fileoverview Utilities for Riff's use of WebRTC
+ *
+ * Created on               July 18, 2019
+ * @author                  Michael Jay Lippert
+ *
+ * @copyright (c) 2019-present Riff Learning Inc.,
+ *                      MIT License (see https://opensource.org/licenses/MIT)
+ *
+ * ******************************************************************************/
+
+// Riff Learning lint overrides
+/* eslint
+    header/header: "off",
+    dot-location: ["error", "property"],
+    indent: ["error", 4, { "CallExpression": { "arguments": "first" }, "ObjectExpression": "first" }],
+    "react/jsx-max-props-per-line": ["error", { "when": "multiline" }],
+    "no-underscore-dangle": ["error", { "allow": [ "_id" ] }],
+*/
+
+// I haven't figured out for sure if we(Riff) want to use the underscore prefix to
+// signify private properties/methods or not, and I've used that convention in here
+// for now, so I'm disabling no-underscore-dangle. -mjl
+/* eslint
+    no-underscore-dangle: off,
+ */
+
+/** The separator character in a riff webrtc nick between the riff id and the display name */
+const NICK_SEPARATOR = '|';
+
+/** The minimum acceptable bitrate for a single stream */
+const MIN_BITRATE = 300; // kbps
+
+/** The maximum allowable total bandwidth consumed by all streams
+ *  given that our requirements state a minimum bandwidth
+ *  of 3 megabits per second, so we come in just a bit below that
+ */
+const MAX_BANDWIDTH = 2700; // kbps
+
+/* ******************************************************************************
+ * WebRtcNick                                                              */ /**
+ *
+ * The WebRtc nick field is used by Riff to store both the riff id and the
+ * display name as a string.
+ * WebRtcNick can be used to extract the id and display name, or to combine
+ * them into the WebRtc nick string.
+ *
+ * You can create an instance of a WebRtcNick with either the nick string
+ * or both the id and display name, and use toString to get the nick, or the
+ * riffId or displayName getters.
+ * Or if you prefer, use one of the static methods: create, getIdAndDisplayName,
+ * getId or getDisplayName;
+ *
+ ********************************************************************************/
+class WebRtcNick {
+    /* **************************************************************************
+     * constructor                                                         */ /**
+     *
+     * WebRtcNick class constructor.
+     */
+    constructor(...args) {
+        this._riffId = null;
+        this._displayName = null;
+
+        // instance properties
+        if (args.length === 1 && typeof args[0] === 'string') {
+            // a single string argument is a riff webrtc nick string
+            [this._riffId, this._displayName] = WebRtcNick.getIdAndDisplayName(args[0]);
+        } else if (args.length === 2 && typeof args[0] === 'string' && typeof args[1] === 'string') {
+            // 2 string arguments means the 1st is the riff ID and the 2nd is the display name
+            [this._riffId, this._displayName] = args;
+        } else {
+            throw new TypeError(`Incorrect arguments for creating a WebRtcNick (${args})`);
+        }
+    }
+
+    toString() {
+        return this._riffId + NICK_SEPARATOR + this._displayName;
+    }
+
+    /*
+     * WebRtcNick property getters/setters
+     */
+
+    get riffId() {
+        return this._riffId;
+    }
+
+    get displayName() {
+        return this._displayName;
+    }
+
+    /*
+     * WebRtcNick static methods
+     */
+
+    /* **************************************************************************
+     * create (static)                                                     */ /**
+     *
+     * Combine the given id and display name into a single string for use as
+     * a webrtc 'nick'.
+     *
+     * @param {string} id
+     * @param {string} displayName
+     *
+     * @returns {string} nick containing the given id and display name in a format
+     *      which can be parsed back into its parts.
+     */
+    static create(id, displayName) {
+        // TODO: some error checks, say for the NICK_SEPARATOR in the values
+        return new WebRtcNick(id, displayName).toString();
+    }
+
+    /* **************************************************************************
+     * getIdAndDisplayName (static)                                        */ /**
+     *
+     * Split a peer's webrtc 'nick' into its two parts:
+     *  the user's display name and their riff ID
+     *
+     *  returns an array with the riff id in the first position
+     *  and the display name in the second
+     *
+     * @param {string} nick - a webrtc 'nick' set by a Riff peer
+     *
+     * @returns {Array<string>} with the 1st element the id and the 2nd the
+     *      display name.
+     */
+    static getIdAndDisplayName(nick) {
+        return nick.split(NICK_SEPARATOR);
+    }
+
+    /* **************************************************************************
+     * getId (static)                                                      */ /**
+     *
+     * Take a peer's webrtc 'nick' and return the peer's riff ID
+     *
+     * @param {string} nick
+     *
+     * @returns {string} the riff Id extracted from the webrtc nick.
+     */
+    static getId(nick) {
+        return WebRtcNick.getIdAndDisplayName(nick)[0];
+    }
+
+    /* **************************************************************************
+     * getDisplayName (static)                                             */ /**
+     *
+     * Take a peer's webrtc 'nick' and return the peer's displayName
+     *
+     * @param {string} nick
+     *
+     * @returns {string} the display name extracted from the webrtc nick.
+     */
+    static getDisplayName(nick) {
+        return WebRtcNick.getIdAndDisplayName(nick)[1];
+    }
+}
+
+/**
+ * Convert a peer array into a readable string listing those peers
+ * using their nicknames.
+ * Useful for a11y aria labels.
+ *
+ * examples:
+ * 0 peers: 'Nobody else is here.'
+ * 1 peer : 'Gerald is in the room.'
+ * 2 peers: 'Aretha and Patty are in the room.'
+ * 3 peers: 'Gerald, Tony and Markus are in the room.'
+ * 4 peers: 'Liz, Gerald, Rebecca and Markus are in the room.'
+ */
+function readablePeers(peers) {
+    // No peers is easy
+    if (peers.length === 0) {
+        return 'Nobody else is here.';
+    }
+
+    const readableSuffix = 'in the room.';
+    const peerNames = peers.map((p) => WebRtcNick.getDisplayName(p.nick));
+
+    // 1 peer is easy
+    if (peerNames.length === 1) {
+        return `${peerNames[0]} is ${readableSuffix}`;
+    }
+
+    // comma separate all names except the last one which is separated by 'and'
+    const readablePeerList = [peerNames.slice(0, -1).join(', '), peerNames.slice(-1)].join(' and ');
+
+    // multiple peers
+    return `${readablePeerList} are ${readableSuffix}`;
+}
+
+/**
+ * Does the needed functionality to support webrtc screen sharing in this browser exist?
+ */
+function isScreenShareSourceAvailable() {
+    // currently we only support chrome v70+ (w/ experimental features enabled, if necessary)
+    // and firefox
+    return Boolean(navigator.getDisplayMedia ||
+                   navigator.mediaDevices.getDisplayMedia ||
+                   navigator.mediaDevices.getSupportedConstraints().mediaSource);
+}
+
+/**
+ * Returns the appropriate bitrate (kbps) for the video streams
+ * based on the number of other peers in the meeting
+ * (e.g. if 2 total people are in a meeting, peerCount is 1)
+ */
+function calculateBitrate(peerCount) {
+    // if we have four or more peers,
+    // we just want to use the lowest possible bitrate
+    // to avoid any cpu limitations
+    if (peerCount >= 4) {
+        return MIN_BITRATE;
+    }
+
+    return MAX_BANDWIDTH / peerCount;
+}
+
+/* **************************************************************************** *
+ * Module exports                                                               *
+ * **************************************************************************** */
+export {
+    WebRtcNick,
+    isScreenShareSourceAvailable,
+    readablePeers,
+    calculateBitrate,
+};


### PR DESCRIPTION
#### Summary
This PR leverages the am-charts package to add a network graph to the dashboard to visualise user interactions in a Mattermost team. The graph starts out with a 'You' node in the center, and as you interact with members of the Mattermost team (course), it progressively adds secondary nodes called 'interaction contexts'. Interaction contexts are all learning groups that a user is a member of and an additional 'course' context to capture interactions that occurred outside the context of a learning group. The numbers in the label on nodes indicate the aggregate interaction count for that user or interaction context. All interaction counts represent a two-way tally. For example, 'Replies: 3', indicates that you have replied to this user, and they have replied to you, a total of 3 times. 

For a detailed summary of the interaction counting rules, refer to:
[https://drive.google.com/open?id=1r0UOb592FGYEj_V8r8fo330WhI7fYMMaRJtRV9vDMlk](url)

I also partially implemented the updates to the dashboard layout, in order to present the network graph in a more visually pleasing manner.

#### Ticket Link
**complete**
https://app.zenhub.com/workspaces/riff-projects-5cb6029b4103d93ceadf001b/issues/rifflearning/zenhub/102

**complete**
https://app.zenhub.com/workspaces/riff-projects-5cb6029b4103d93ceadf001b/issues/rifflearning/zenhub/100

**complete**
https://app.zenhub.com/workspaces/riff-projects-5cb6029b4103d93ceadf001b/issues/rifflearning/zenhub/103 

**complete**
https://app.zenhub.com/workspaces/riff-projects-5cb6029b4103d93ceadf001b/issues/rifflearning/zenhub/101

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [x] Has redux changes (please link)
- [x] Has UI changes
