### PR TITLE
Improved accessibility for the meeting mediator

### DIFF
--- a/components/dashboard/components/ChartCard.jsx
+++ b/components/dashboard/components/ChartCard.jsx
@@ -137,7 +137,7 @@ const ChartCard = enhance((props) => {
                         onClick={() => props.dispatch({type: INFO_CLICKED})}
                         aria-describedby={`chart-info-${props.chartCardId}`}
                         id={`chart-info-btn-${props.chartCardId}`}
-                        tabIndex='-1'
+                        tabIndex='0'
                     >
                         <MaterialIcon icon='info'/>
                     </button>

--- a/components/webrtc_view_bulma/charts/mm.coffee
+++ b/components/webrtc_view_bulma/charts/mm.coffee
@@ -165,6 +165,7 @@
       # new node groups - add attributes and child elements
       nodeGsEnter = nodeGs.enter().append "g"
         .attr "class", "node"
+        .attr "tabindex", "0"
         .attr "id", (d) -> d.participant
 
       nodeGsEnter.append "circle"
@@ -196,7 +197,7 @@
             "#000000"
 
       # show tooltip on hover
-      nodeGsEnter.on "mouseover", (d) =>
+      nodeGsEnter.on "mouseover, focus", (d) =>
         tooltipText = ""
         position = document.getElementById('circle-' + d.participant).getBoundingClientRect()
         leftPosition = (position.x + (position.width / 2)) - (TOOLTIP_WIDTH / 2) + window.scrollX
@@ -211,12 +212,13 @@
           speakingTime = @getSpeakingTime(d.participant)
           tooltipText = "Name: " + d.name + "<br/>Speaking Time: " + speakingTime
         @tooltip.html(tooltipText)
+          .attr "role", "alert"
           .style "left", leftPosition + "px"
           .style "top", topPosition + "px"
           .style "display", "flex"
 
       # hide tooltip
-      nodeGsEnter.on "mouseout", (d) =>
+      nodeGsEnter.on "mouseout, focusout", (d) =>
         @tooltip.html("")
         @tooltip.style "display", "none"
 


### PR DESCRIPTION
#### Summary
Made the nodes in the meeting mediator focusable by adding a tabindex of 0 (which places the tabindex in the natural order in the document)

Made the tooltips for the nodes in the meeting mediator appear on focus

Added role 'alert' to tooltip so screen readers will read out the contents. The role 'alert' is recommended to be used sparingly because it interrupts what is currently be read out. However, other aria attributes didn't read out the entire tooltip. The only way this will get read aloud is if the user, with a screenreader enabled, either focuses or hovers over a node. So I think this is okay.

Made the info icon in chart cards focusable with tab. The tabindex was previously set to -1, which meant it was focusable, but not by tabbing. I think we want this tabbable, in the dashboard as well.

#### Ticket Link
rifflearning/zenhub#64

#### Checklist
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes

