### PR TITLE
Add aria labels to each node on the course connections graph

### DIFF
--- a/components/dashboard/.eslintrc.json
+++ b/components/dashboard/.eslintrc.json
@@ -27,10 +27,24 @@
         "CallExpression": { "arguments": "first" }
       }
     ],
+    "key-spacing": [
+        "error",
+        {
+          "beforeColon": false,
+          "afterColon": true,
+          "mode": "minimum"
+        }
+    ],
     "no-underscore-dangle": [
       "error",
       {
         "allow": [ "_id" ]
+      }
+    ],
+    "no-unused-expressions": [
+      "error",
+      {
+        "allowShortCircuit": true
       }
     ],
     "react/jsx-max-props-per-line": [

--- a/utils/riff/user_analytic_utils.js
+++ b/utils/riff/user_analytic_utils.js
@@ -324,6 +324,42 @@ class InteractionCounts {
     }
 }
 
+/* ******************************************************************************
+ * getInteractionCountPhrase                                                     */ /**
+ *
+ * get either the singular or plural summary phrase for
+ * a given interaction type and count
+ *
+ * @param {string} type - the type of interaction
+ * @param {number} count - the number of interactions of this type
+ *
+ *
+ * @returns {string} a summary phrase for an interaction type and count.
+ */
+function getInteractionCountPhrase(type, count) {
+    switch (type) {
+    case 'reply': {
+        return `${count} ${count === 1 ? 'reply' : 'replies'}`;
+    }
+    case 'mention': {
+        return `${count} ${count === 1 ? 'mention' : 'mentions'}`;
+    }
+    case 'directMessage': {
+        return `${count} ${count === 1 ? 'direct message' : 'direct messages'}`;
+    }
+    case 'reaction': {
+        return `${count} ${count === 1 ? 'reaction' : 'reactions'}`;
+    }
+    case 'post': {
+        return `${count} ${count === 1 ? 'post' : 'posts'}`;
+    }
+    case 'aggregate': {
+        return `${count} ${count === 1 ? 'contact' : 'contacts'}`;
+    }
+    }
+    return false;
+}
+
 /* **************************************************************************** *
  * Module exports                                                               *
  * **************************************************************************** */
@@ -332,4 +368,5 @@ export {
     InteractionCounts,
     InteractionContext,
     UserInContext,
+    getInteractionCountPhrase,
 };

--- a/utils/riff/user_analytic_utils.js
+++ b/utils/riff/user_analytic_utils.js
@@ -330,19 +330,19 @@ class InteractionCounts {
  * get either the singular or plural summary phrase for
  * a given interaction type and count
  *
- * @param {string} type - the type of interaction
+ * @param {string} type - An InteractionType, or 'aggregate'
  * @param {number} count - the number of interactions of this type
  *
- * @returns {string} a summary phrase for an interaction type and count.
+ * @returns {string} a summary phrase for the interaction type and count.
  */
 function getInteractionCountPhrase(type, count) {
     /* eslint-disable no-multi-spaces */
     const typePhrases = {
-        reply:          {singular: 'reply',             plural: 'replies'},
-        mention:        {singular: 'mention',           plural: 'mentions'},
-        directMessage:  {singular: 'direct message',    plural: 'direct messages'},
-        reaction:       {singular: 'reaction',          plural: 'reactions'},
-        post:           {singular: 'post',              plural: 'posts'},
+        Reply:          {singular: 'reply',             plural: 'replies'},
+        Mention:        {singular: 'mention',           plural: 'mentions'},
+        DirectMessage:  {singular: 'direct message',    plural: 'direct messages'},
+        Reaction:       {singular: 'reaction',          plural: 'reactions'},
+        Post:           {singular: 'post',              plural: 'posts'},
         aggregate:      {singular: 'contact',           plural: 'contacts'},
     };
     /* eslint-enable no-multi-spaces */

--- a/utils/riff/user_analytic_utils.js
+++ b/utils/riff/user_analytic_utils.js
@@ -325,7 +325,7 @@ class InteractionCounts {
 }
 
 /* ******************************************************************************
- * getInteractionCountPhrase                                                     */ /**
+ * getInteractionCountPhrase                                               */ /**
  *
  * get either the singular or plural summary phrase for
  * a given interaction type and count
@@ -333,31 +333,24 @@ class InteractionCounts {
  * @param {string} type - the type of interaction
  * @param {number} count - the number of interactions of this type
  *
- *
  * @returns {string} a summary phrase for an interaction type and count.
  */
 function getInteractionCountPhrase(type, count) {
-    switch (type) {
-    case 'reply': {
-        return `${count} ${count === 1 ? 'reply' : 'replies'}`;
-    }
-    case 'mention': {
-        return `${count} ${count === 1 ? 'mention' : 'mentions'}`;
-    }
-    case 'directMessage': {
-        return `${count} ${count === 1 ? 'direct message' : 'direct messages'}`;
-    }
-    case 'reaction': {
-        return `${count} ${count === 1 ? 'reaction' : 'reactions'}`;
-    }
-    case 'post': {
-        return `${count} ${count === 1 ? 'post' : 'posts'}`;
-    }
-    case 'aggregate': {
-        return `${count} ${count === 1 ? 'contact' : 'contacts'}`;
-    }
-    }
-    return false;
+    /* eslint-disable no-multi-spaces */
+    const typePhrases = {
+        reply:          {singular: 'reply',             plural: 'replies'},
+        mention:        {singular: 'mention',           plural: 'mentions'},
+        directMessage:  {singular: 'direct message',    plural: 'direct messages'},
+        reaction:       {singular: 'reaction',          plural: 'reactions'},
+        post:           {singular: 'post',              plural: 'posts'},
+        aggregate:      {singular: 'contact',           plural: 'contacts'},
+    };
+    /* eslint-enable no-multi-spaces */
+
+    const unknownTypePhrase = {singular: '', plural: ''};
+    const typePhrase = typePhrases[type] || unknownTypePhrase;
+
+    return `${count} ${count === 1 ? typePhrase.singular : typePhrase.plural}`;
 }
 
 /* **************************************************************************** *


### PR DESCRIPTION
#### Summary
Leveraged the amcharts node config property 'readerDescription' to add an aria-describedby property to every node on the graph. 

Different functions must be called on interaction context nodes and user nodes to retrieve the totals for each interaction type. This introduced a bit of complexity in the `getAriaLabel()` function. There are two resulting functions for getting aria-labels for context and user nodes.

Also added a utility function for obtaining a summary phrase for interaction types and counts.
Ex. `(reaction, 3) => '3 reactions'`, `('reaction, 1) => '1 reaction' `

#### Ticket Link
rifflearning/zenhub#165

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)