### PR TITLE
Update info for course connections chart card

### DIFF
--- a/components/dashboard/components/ChartCard.jsx
+++ b/components/dashboard/components/ChartCard.jsx
@@ -72,13 +72,15 @@ const StyledInfo = styled.p.attrs({
 })`
     padding: 2rem;
     color: #fff;
+    white-space: pre-line;
 `;
 
 const StyledInfoSmall = styled.p.attrs({
     className: 'is-size-7',
 })`
-padding: 2rem 0.5rem 0.5rem 0.5rem;
-color: #fff;
+    padding: 2rem 0.5rem 0.5rem 0.5rem;
+    color: #fff;
+    white-space: pre-line;
 `;
 
 const INFO_CLICKED = 'INFO_CLICKED';

--- a/components/dashboard/components/CourseConnections/CourseConnectionsView.jsx
+++ b/components/dashboard/components/CourseConnections/CourseConnectionsView.jsx
@@ -79,6 +79,18 @@ class CourseConnectionsView extends React.Component {
         fetchUserInteractions: PropTypes.func,
     };
 
+    /**
+     * Description of this chart that is presented to the user via the ChartCard info button
+     * @type {string}
+     */
+    static chartInfo =
+        'This metric shows how many times you\'ve connected with members of your group(s) ' +
+        'and other people in the course. Connections are a total of your posts, direct ' +
+        'messages, mentions, replies, and reactions in Riff.\n' +
+        '\n' +
+        'Learners who engage with their peers are more likely to complete the course, ' +
+        'and have higher grades.';
+
     constructor(props) {
         super(props);
 
@@ -126,10 +138,6 @@ class CourseConnectionsView extends React.Component {
     }
 
     render() {
-        const chartInfo = 'This metric shows how many times you\'ve connected with members of your group(s) and other people in the course.' +
-        ' Connections are a total of your direct messages, mentions, replies, and reactions in Riff.' +
-        '\n Learners who engage with their peers are more likely to complete the course, and have higher grades.';
-
         const networkGraph = <div id='network-graph-div' style={{width: '100%', height: '100%'}}/>;
 
         return (
@@ -137,7 +145,7 @@ class CourseConnectionsView extends React.Component {
                 <ChartCard
                     title={'Course Interactions'}
                     chartDiv={networkGraph}
-                    chartInfo={chartInfo}
+                    chartInfo={CourseConnectionsView.chartInfo}
                     chartTable={false}
                     chartCardId={'cc-network-graph'}
                     isNetworkGraphCard={true}


### PR DESCRIPTION
#### Summary
Update the text on the back of the chard card for the course connections graph. The text now includes a reference to Posts.

Also, add `white-space: pre-line;` to the css for the container of that text, to allow for new lines with `\n`.

#### Ticket Link
rifflearning/zenhub#164

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes