### PR TITLE
Fix mismatched error messages which result in dashboard breaking

### DIFF
--- a/actions/views/dashboard.js
+++ b/actions/views/dashboard.js
@@ -18,6 +18,7 @@ import {
     logger,
     mapObject,
     reverseCmp,
+    LoadMeetingErrorTypes,
 } from 'utils/riff';
 
 export const loadMoreMeetings = () => {
@@ -63,7 +64,7 @@ export const loadRecentMeetings = (uid) => (dispatch) => {
         .then((res) => {
             if (res.data.length === 0) {
                 // no found participants. Throw an error to break out early.
-                throw new Error('no participant');
+                throw new Error(LoadMeetingErrorTypes.NO_PARTICIPANT);
             }
             logger.debug('>>fetched participant:', res);
             return res.data[0];
@@ -88,7 +89,7 @@ export const loadRecentMeetings = (uid) => (dispatch) => {
             });
 
             if (usefulMeetings.length === 0) {
-                throw new Error('no useful meetings after filter');
+                throw new Error(LoadMeetingErrorTypes.NO_USEFUL_MEETINGS);
             }
 
             // fetch data for first meeting
@@ -129,7 +130,7 @@ export const loadRecentMeetings = (uid) => (dispatch) => {
             });
             logger.debug('kept meetings:', meetingsWithOthers);
             if (meetingsWithOthers.length === 0) {
-                throw new Error('no meetings after participants filter');
+                throw new Error(LoadMeetingErrorTypes.NO_MEETINGS_WITH_OTHERS);
             }
             meetingsWithOthers.sort(reverseCmp(cmpObjectProp('startTime'))); // sort by descending time
 
@@ -146,23 +147,21 @@ export const loadRecentMeetings = (uid) => (dispatch) => {
             }
         })
         .catch((err) => {
-            if (err.message === 'no participant') {
+            if (err.message === LoadMeetingErrorTypes.NO_PARTICIPANT) {
                 dispatch({
                     type: DashboardActionTypes.DASHBOARD_LOADING_ERROR,
                     status: true,
                     message:
                         'No meetings found. Meetings that last for over two minutes will show up here.',
                 });
-            } else if (err.message === 'no useful meetings after filter') {
+            } else if (err.message === LoadMeetingErrorTypes.NO_USEFUL_MEETINGS) {
                 dispatch({
                     type: DashboardActionTypes.DASHBOARD_LOADING_ERROR,
                     status: true,
                     message:
                         "We'll only show meetings that lasted for over two minutes. Go have a riff!",
                 });
-            } else if (
-                err.message === 'no meetings after nparticipants filter'
-            ) {
+            } else if (err.message === LoadMeetingErrorTypes.NO_MEETINGS_WITH_OTHERS) {
                 dispatch({
                     type: DashboardActionTypes.DASHBOARD_LOADING_ERROR,
                     status: true,

--- a/actions/views/dashboard.js
+++ b/actions/views/dashboard.js
@@ -121,7 +121,7 @@ export const loadRecentMeetings = (uid) => (dispatch) => {
             });
 
             // TODO: this will include meetings where someone joins but does not speak.
-            // because we use the utterance data to inform our shit, the # of attendees will also be wrong.
+            // because we use the utterance data to inform our stuff, the # of attendees will also be wrong.
             // right thing to do here is to try and create a service on the server that will reliably give
             // us # of attendees
             logger.debug('num participants:', numParticipants, meetings);

--- a/actions/views/riff.js
+++ b/actions/views/riff.js
@@ -21,7 +21,7 @@ export const riffAuthFail = (err) => {
 };
 
 export const updateTurnData = (transitions, turns) => {
-    logger.debug('updating turn data:', transitions, turns);
+    logger.debug('RiffActions: updating turn data:', {transitions, turns});
     return {
         type: RiffServerActionTypes.RIFF_TURN_UPDATE,
         transitions,
@@ -30,7 +30,7 @@ export const updateTurnData = (transitions, turns) => {
 };
 
 export const updateMeetingParticipants = (participants) => {
-    logger.debug('updating riff meeting participants', participants);
+    logger.debug('RiffActions: updating riff meeting participants', participants);
     return {
         type: RiffServerActionTypes.RIFF_PARTICIPANTS_CHANGED,
         participants,
@@ -51,11 +51,11 @@ export const participantLeaveRoom = (meetingId, participantId) => {
             remove_participants: [participantId],
         }).
         then(() => {
-            logger.debug(`removed participant: ${participantId} from meeting ${meetingId}`);
+            logger.debug(`RiffActions: removed participant: ${participantId} from meeting ${meetingId}`);
             return true;
         }).
         catch((err) => {
-            logger.error('caught an error:', err);
+            logger.error(`RiffActions: couldn't remove participant: ${participantId} from meeting ${meetingId}`, err);
             return false;
         });
 };
@@ -67,15 +67,15 @@ export const attemptRiffAuthenticate = () => (dispatch) => {
         password: 'default-user-password',
     }).
         then((result) => {
-            logger.debug('riff data server auth result!: ', result);
+            logger.info('RiffActions: Riff data server authentication: Succeeded');
             dispatch(riffAuthSuccess(result.accessToken));
 
             //return this.recordMeetingJoin();
         }).
         catch((err) => {
-            logger.warn('riff data server auth ERROR:', err);
+            logger.warn('RiffActions: Riff data server authentication: Failed', err);
             dispatch(riffAuthFail(err));
-            logger.info('trying to authenticate again...');
+            logger.info('RiffActions: Riff data server authentication: Retrying...');
             dispatch(attemptRiffAuthenticate());
         });
 };

--- a/actions/views/riff.js
+++ b/actions/views/riff.js
@@ -55,7 +55,7 @@ export const participantLeaveRoom = (meetingId, participantId) => {
             return true;
         }).
         catch((err) => {
-            logger.error('shit, caught an error:', err);
+            logger.error('caught an error:', err);
             return false;
         });
 };

--- a/actions/webrtc_actions.js
+++ b/actions/webrtc_actions.js
@@ -25,7 +25,7 @@ export const riffParticipantLeaveRoom = (riffMeetingId, riffId) => (/*dispatch*/
             return true;
         })
         .catch((err) => {
-            logger.error('shit, caught an error:', err);
+            logger.error('caught an error:', err);
             return false;
         });
 };

--- a/actions/webrtc_actions.js
+++ b/actions/webrtc_actions.js
@@ -21,11 +21,11 @@ export const riffParticipantLeaveRoom = (riffMeetingId, riffId) => (/*dispatch*/
             remove_participants: [riffId],
         })
         .then(() => {
-            logger.debug(`removed participant: ${riffId} from meeting ${riffMeetingId}`);
+            logger.debug(`WebrtcAction: removed participant: ${riffId} from meeting ${riffMeetingId}`);
             return true;
         })
         .catch((err) => {
-            logger.error('caught an error:', err);
+            logger.error('WebrtcAction: couldn\'t remove participant from meeting', err);
             return false;
         });
 };
@@ -41,7 +41,7 @@ export const handleMuteAudioClick = (event, muted, webrtc) => (dispatch) => {
 };
 
 export const joinWebRtcRoom = (roomName, teamId, videoId) => (dispatch) => {
-    logger.debug('Joining webrtc room', roomName, teamId, videoId);
+    logger.debug('WebrtcAction: Joining webrtc room', roomName, teamId, videoId);
     dispatch(joinRoom(`${roomName}-${videoId}`));
     browserHistory.push(`/${teamId}/${roomName}/video/${videoId}`);
 };
@@ -55,7 +55,7 @@ export const handleReadyClick = (event, props, webrtc) => (dispatch) => {
         dispatch(joinRoomError('Make sure your camera and microphone are ready, and refresh the page.'));
     } else {
         // add user to riff meetings
-        logger.debug('adding user to meetings with props:', props);
+        logger.debug('WebrtcAction: adding user to meetings with props:', props);
         event.preventDefault();
         riffAddUserToMeeting(
             props.user.id,
@@ -86,9 +86,9 @@ export const handleScreenShareClick = (event, isUserSharing, webRtcRemoteSharedS
     } else if (webRtcRemoteSharedScreen) {
         // someone is already sharing
         // TODO tell user to quit it
-        logger.debug('Stop that, someone is already sharing!');
+        logger.debug('WebrtcAction: Stop that, someone is already sharing!');
     } else {
-        logger.debug('Sharing screen!');
+        logger.debug('WebrtcAction: Sharing screen!');
         dispatch(shareScreen());
         webrtc.shareScreen();
     }
@@ -191,14 +191,14 @@ export const sendTextChatMsg = (message, participant, meeting) => (dispatch) => 
             meeting,
         })
         .then((result) => {
-            logger.debug('created a message!', result);
+            logger.debug('WebrtcAction.sendTextChatMsg: added message to messages service', result);
             dispatch(updateTextChat(result.msg,
                                     result.meeting,
                                     result.participant,
                                     result.time));
         })
         .catch((err) => {
-            logger.error('errored out', err);
+            logger.error('WebrtcAction.sendTextChatMsg: couldn\'t add message to service', err);
         });
 };
 

--- a/utils/riff/index.js
+++ b/utils/riff/index.js
@@ -153,6 +153,12 @@ function addA11yBrowserAlert(text, priority = 'polite') {
     }, 1000);
 }
 
+const LoadMeetingErrorTypes = {
+    NO_PARTICIPANT: 'no participant found',
+    NO_USEFUL_MEETINGS: 'no useful meetings found',
+    NO_MEETINGS_WITH_OTHERS: 'no meetings with other participants found',
+};
+
 /* **************************************************************************** *
  * Module exports                                                               *
  * **************************************************************************** */
@@ -181,4 +187,5 @@ export {
     calculateBitrate,
     isScreenShareSourceAvailable,
     readablePeers,
+    LoadMeetingErrorTypes,
 };


### PR DESCRIPTION
### Summary
Currently, if a user has only ever created meetings without any other users joining them, the dashboard will break when the user attempts to view it. This fix ensures the values are the same by using constants instead of manually typed strings.

Note - I was torn between putting `LoadMeetingErrorTypes` in `utils/riff` and `utils/constants`. It looked to me that `utils/constants` was mostly constants related to actions, so I put it in `utils/riff`, but I'm open to suggestions.

Also, while I was here, I changed some of the less... polite... error messages to be a bit more user friendly

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Includes text changes and localization file ([.../i18n/en.json](https://github.com/mattermost/mattermost-webapp/blob/master/i18n/en.json)) updates
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
