### PR TITLE
display course connections recommendation in week 8

### DIFF
--- a/utils/riff/recommendations/index.jsx
+++ b/utils/riff/recommendations/index.jsx
@@ -128,7 +128,7 @@ function getRecommendations(userId, teamId, learningGroups, courseStartTime) {
         userId,
         // eslint-disable-next-line no-magic-numbers
         5, //first week to display this recommendation
-        3, // number of weeks to display for
+        4, // number of weeks to display for
         0, // relative priority to other recs for this week
         async () => {
             // TODO see about doing this via redux and the state -mjl 2019-09-09


### PR DESCRIPTION

#### Summary
This recommendation is supposed to be displayed in weeks 5 - 8, currently it is only displaying in 5 - 7. Just bumped the number of weeks to display up by one.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Ran `make test` to ensure unit and component tests passed
- [ ] Added or updated unit tests (required for all new features)
- [ ] Has UI changes
- [ ] Touches critical sections of the codebase (auth, posting, etc.)
