### PR TITLE
Use riff colors in color enum for connections graph

### DIFF
--- a/reducers/views/webrtc.js
+++ b/reducers/views/webrtc.js
@@ -16,7 +16,7 @@ import {joinWebRtcRoom} from 'actions/webrtc_actions';
 const initialState = {
     peerColors: [
         Colors.reddishPeach,
-        Colors.turkoise,
+        Colors.turquoise,
         Colors.sage,
         Colors.apricot,
         Colors.eggplant,

--- a/sass/components/_bulma.scss
+++ b/sass/components/_bulma.scss
@@ -50,7 +50,7 @@ $blue: rgb(19,129,161);
 
 $brightPlum: #ab45ab;
 $reddishPeach: #f56b6b;
-$turkoise: #128ead;
+$turquoise: #128ead;
 $sage: #7caf5f;
 $apricot: #f2a466;
 $eggplant: #321325;
@@ -80,7 +80,7 @@ html {
 }
 
 .riff-peer-1 {
-    color: $turkoise;
+    color: $turquoise;
 }
 
 .riff-peer-2 {

--- a/utils/riff/colors.js
+++ b/utils/riff/colors.js
@@ -36,7 +36,7 @@
  */
 const Colors = {
     black:            '#000000',
-    turkoise:         '#128ead',
+    turquoise:        '#128ead',
     aquamarine:       '#1b998b',
     eggplant:         '#321325',
     darkFern:         '#3c493f',
@@ -68,7 +68,7 @@ const Colors = {
 const PeerColors = [
     Colors.brightPlum,
     Colors.reddishPeach,
-    Colors.turkoise,
+    Colors.turquoise,
     Colors.sage,
     Colors.apricot,
     Colors.eggplant,
@@ -94,7 +94,7 @@ const networkGraphNodeColors = {
     },
     learningGroupColors: [
         {
-            backgroundColor: Colors.turkoise,
+            backgroundColor: Colors.turquoise,
             fontColor: Colors.black,
         },
         {

--- a/utils/riff/colors.js
+++ b/utils/riff/colors.js
@@ -85,24 +85,24 @@ const PeerColors = [
  */
 const networkGraphNodeColors = {
     you: {
-        backgroundColor: '#8e7cc3', // purple
+        backgroundColor: Colors.brightPlum,
         fontColor: Colors.white,
     },
     course: {
-        backgroundColor: '#6aa84f', // green
+        backgroundColor: Colors.sage,
         fontColor: Colors.black,
     },
     learningGroupColors: [
         {
-            backgroundColor: '#2b78e4', // blue
+            backgroundColor: Colors.turkoise,
             fontColor: Colors.black,
         },
         {
-            backgroundColor: '#f6b26b', // orange
+            backgroundColor: Colors.apricot,
             fontColor: Colors.black,
         },
         {
-            backgroundColor: '#db4c40', // red
+            backgroundColor: Colors.redPunch,
             fontColor: Colors.black,
         },
     ],
@@ -200,7 +200,7 @@ function getCountOtherColors(cnt) {
  *      containing the background and font colors for the nth learning group.
  */
 function getColorForLearningGroup(n) {
-    const i = (n % (networkGraphNodeColors.learningGroupColors.length - 1)) + 1;
+    const i = (n % (networkGraphNodeColors.learningGroupColors.length - 1));
     return networkGraphNodeColors.learningGroupColors[i];
 }
 


### PR DESCRIPTION
#### Summary
Use the defined colors in the color enum for all colors in the course connections graph. 

Fix getColorForLearningGroup() function. Didn't need to add 1 in algorithm, mistakenly copied this from getColorForOther() function, which added 1 to avoid using the color for 'you'.

#### Ticket Link
rifflearning/zenhub#183

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [x] Has UI changes
