### PR TITLE
Filter riffbot DM's from course connections graph

### DIFF
--- a/components/dashboard/components/CourseConnections/CourseConnectionsView.jsx
+++ b/components/dashboard/components/CourseConnections/CourseConnectionsView.jsx
@@ -210,8 +210,16 @@ class CourseConnectionsView extends React.Component {
      * Draw the graph w/ the latest interaction data
      */
     drawGraph() {
-        const {userInteractions, userLearningGroups} = this.props;
+        const userLearningGroups = this.props.userLearningGroups;
         const learningGroupTypes = this.sortedLearningGroupTypes;
+
+        /** DevNote: This is a temporary solution that filters direct messages sent by 'riffbot'
+         *          out of the user interactions. This is to prevent them from appearing on the
+         *          course connections graph. In the future, the user interactions query in
+         *          mattermost-server will be refactored, and will account for this, and we can
+         *          remove this filter at that point.
+         */
+        const userInteractions = this.props.userInteractions.filter((interaction) => interaction.Username !== 'riffbot');
 
         // this will summarize the current user's overall context interactions for the 'you' node
         const currentUserOverallContext = new UserInContext({


### PR DESCRIPTION
#### Summary
Since we don't want direct messages sent from 'riffbot' to count as interactions and appear in the course connections graph, we want to filter them out. This will ideally be done in the SQL query. Since we are planning to refactor the SQL query at some point, we are temporarily filtering on the front-end. Although Recommendations also uses the user interactions data, from as far as I can tell, direct messages from 'riffbot' won't have an affect on recommendations. 

It doesn't seem like the pending PR for the refactor of recommendations will have an effect on what was done here.

#### Ticket Link
rifflearning/zenhub#185

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
