### PR TITLE
remove bogus ref string attributes

### DIFF
--- a/components/webrtc_view_bulma/RemoteVideoContainer.jsx
+++ b/components/webrtc_view_bulma/RemoteVideoContainer.jsx
@@ -145,7 +145,7 @@ class RemoteVideoContainer extends React.Component {
     render() {
         return (
             <div className='remotes' id='remoteVideos'>
-                <div ref='remotes' className='columns is-multiline is-centered is-mobile'>
+                <div className='columns is-multiline is-centered is-mobile'>
                     {this.videos()}
                 </div>
             </div>

--- a/components/webrtc_view_bulma/RenderVideos.jsx
+++ b/components/webrtc_view_bulma/RenderVideos.jsx
@@ -88,7 +88,6 @@ class RenderVideos extends React.Component {
                         aria-label={`Video chat. ${readablePeers(this.props.webRtcPeers)}`}
                     >
                         <RemoteVideoContainer
-                            ref='remote'
                             peers={this.props.webRtcPeers}
                             chat={this.props.chat}
                             remoteSharedScreen={this.props.webRtcRemoteSharedScreen}

--- a/components/webrtc_view_bulma/styled.js
+++ b/components/webrtc_view_bulma/styled.js
@@ -17,7 +17,6 @@ left: 1rem;
 
 export const VideoPlaceholder = styled.div.attrs({
     className: 'has-text-centered',
-    ref: 'local',
 })`
 background: linear-gradient(30deg, rgba(138,106,148,1) 12%, rgba(171,69,171,1) 87%);
 height: 144px;


### PR DESCRIPTION
#### Summary
Chat is not loading in the said-oxford deployment. We are getting this message in the console (well it leads to this message):

> Element ref was specified as a string (local) but no owner was set. This could happen for one of the following reasons: 1. You may be adding a ref to a function component 2. You may be adding a ref to a component that was not created inside a component's render method 3. You have multiple copies of React loaded See https://fb.me/react-refs-must-have-owner for more information

I'm pretty sure this was caused by the ref in `styled.js`

#### Ticket Link
no ticket was created.

#### Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [x] Ran `make check-style` to check for style errors (required for all pull requests)
- [ ] Ran `make test` to ensure unit and component tests passed


