### PR TITLE
Changes to fix login with LTI

### DIFF
--- a/components/signup/signup_lti/index.js
+++ b/components/signup/signup_lti/index.js
@@ -7,6 +7,8 @@ import {bindActionCreators} from 'redux';
 import {getConfig} from 'mattermost-redux/selectors/entities/general';
 import {createLTIUser} from 'mattermost-redux/actions/users';
 
+import {login} from 'actions/views/login';
+
 import {getPasswordConfig} from 'utils/utils.jsx';
 
 import SignupLTI from './signup_lti.jsx';
@@ -34,6 +36,7 @@ function mapDispatchToProps(dispatch) {
     return {
         actions: bindActionCreators({
             createLTIUser,
+            login,
         }, dispatch),
     };
 }


### PR DESCRIPTION
So, I was able to get most of the LTI login/signup to work. Here's some of the stuff I needed to change:

1. The `Base64` encoded launch data cookie was not being set in my local environment. I could get that to work by making the cookie shorter by encoding it with `URL encoding`. This may not be a required change for riff if the launch data sent from your LMS is small enough.
This may also be dependent on the browser version. I am using `Chromium 83.0.4103.61 on Ubuntu 18.04`.

2. Login was not working after setting the password from the `signup_lti` page. I haven't had a chance to fully investigate the changes done to the Auth flow by MM due to which our code stopped working. To fix this, I had to login by making an API call from the webapp. This is now similar to the `signup_email` component.

3. Trying to follow the login using LTI link when already logged in to Mattermost shows up as a CSRF attempt and does not work. Here are the relevant logs:

```
DEBU[2020-06-30T20:22:45.8838549+05:30] Invalid or expired session, please login again.  caller="mlog/log.go:163" err_details="token=xk6fdw6aspy5tfmojgqh85neyo Appears to be a CSRF attempt" err_where=ServeHTTP http_code=401 ip_addr="2401:4900:30d3:357f:f0ad:2fd0:c0ad:ceff" method=POST path=/login/lti request_id=n31ymhaydibgtgnznpafpafitc user_id=
```

Note: I have not tested the entire LTI Auth functionality, just that we can login successfully

