### PR TITLE
update mattermost redux package commit for unarchive teams

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20250,8 +20250,8 @@
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "mattermost-redux": {
-      "version": "github:rifflearning/mattermost-redux#641938697a8161fabc0802d252bc1ab5a6ab34d4",
-      "from": "github:rifflearning/mattermost-redux#641938697a8161fabc0802d252bc1ab5a6ab34d4",
+      "version": "github:rifflearning/mattermost-redux#db2c52dc4b7bfe3fae34a288106a2cc86e394a89",
+      "from": "github:rifflearning/mattermost-redux#db2c52dc4b7bfe3fae34a288106a2cc86e394a89",
       "requires": {
         "core-js": "3.8.3",
         "form-data": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "localforage-observable": "2.1.1",
     "mark.js": "8.11.1",
     "marked": "github:mattermost/marked#be741d411d4642c4cd3e009645f4cb6baa7e92bb",
-    "mattermost-redux": "github:rifflearning/mattermost-redux#641938697a8161fabc0802d252bc1ab5a6ab34d4",
+    "mattermost-redux": "github:rifflearning/mattermost-redux#db2c52dc4b7bfe3fae34a288106a2cc86e394a89",
     "moment-timezone": "0.5.31",
     "p-queue": "6.6.1",
     "pdfjs-dist": "2.1.266",


### PR DESCRIPTION
### Summary
Update the `mattermost-redux` package version to the commit in rifflearning/mattermost-redux which adds the unarchive teams support.

This change really should have been in PR #116, but I forgot to add it, after the rifflearning/mattermost-redux#9 PR was merged.
